### PR TITLE
Rest fix

### DIFF
--- a/src/main/java/InfrastructureManager/Master.java
+++ b/src/main/java/InfrastructureManager/Master.java
@@ -65,7 +65,7 @@ public class Master {
      */
     private void startRestRunnerThread() throws Exception {
         for (Runner runner : runnerList) {
-            if (runner.getName().equals("Rest") && restThread == null) {
+            if (runner.getName().equals("RestServer") && restThread == null) {
                 restThread = new Thread(runner, "RestRunner");
                 restThread.start();
                 break;

--- a/src/main/java/InfrastructureManager/Master.java
+++ b/src/main/java/InfrastructureManager/Master.java
@@ -63,11 +63,15 @@ public class Master {
     /**
      * Method for starting the REST runner thread, declared in the config file
      */
-    private void startRestRunnerThread() throws Exception {
+    public void startRunnerThread(String name){
         for (Runner runner : runnerList) {
-            if (runner.getName().equals("RestServer") && restThread == null) {
-                restThread = new Thread(runner, "RestRunner");
-                restThread.start();
+            if (runner.getName().equals(name)) {
+                if (name.equals("RestServer") && restThread == null) {
+                    restThread = new Thread(runner, "RestRunner");
+                    restThread.start();
+                    break;
+                }
+                new Thread(runner,name).start();
                 break;
             }
         }
@@ -176,8 +180,8 @@ public class Master {
 
     public static void main(String[] args) {
         Master.getInstance().startMainRunner();
+        Master.getInstance().startRunnerThread("RestServer");
         try {
-            Master.getInstance().startRestRunnerThread();
             Master.getInstance().getMainThread().join();
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/InfrastructureManager/MasterConfigurator.java
+++ b/src/main/java/InfrastructureManager/MasterConfigurator.java
@@ -80,6 +80,8 @@ public class MasterConfigurator {
                 case "rest":
                     result[i] = new RestOutput();
                     break;
+                case "":
+                    break;
                 default:
                     throw new IllegalArgumentException("Invalid output in Configuration");
             }
@@ -103,8 +105,9 @@ public class MasterConfigurator {
                name = runnerData.getName();
                if (runnerData.isScenario()) { //Input as scenario name if is an scenario runner
                    result.add(new ScenarioRunner(name,input,output));
-               } else if (name.equals("Rest")) {
-                   result.add(RestRunner.getRestRunner(name,getInput(input),output));
+               } else if (name.equals("RestServer")) {
+                   String portNumber = input.replaceAll("[^\\d]*","");
+                   result.add(RestRunner.getRestRunner(name, Integer.parseInt(portNumber)));
                } else { //Input as masterInput
                    result.add(new Runner(name,getInput(input),output));
                }

--- a/src/main/java/InfrastructureManager/MasterUtility.java
+++ b/src/main/java/InfrastructureManager/MasterUtility.java
@@ -18,6 +18,9 @@ public class MasterUtility implements MasterOutput {
                     case "exit" :
                         Master.getInstance().exitAll();
                         break;
+                    case "runRunner":
+                        Master.getInstance().startRunnerThread(command[2]);
+                        break;
                     default:
                         throw new IllegalArgumentException("Invalid Command for Utility Output");
                 }

--- a/src/main/java/InfrastructureManager/Rest/RestInput.java
+++ b/src/main/java/InfrastructureManager/Rest/RestInput.java
@@ -6,7 +6,6 @@ import spark.*;
 
 public class RestInput implements MasterInput {
     private static String command = "";
-    private static Master master = Master.getInstance();
 
     public static Route readParameterTest = (Request request, Response response) -> request.params(":input");
 

--- a/src/main/java/InfrastructureManager/Rest/RestRunner.java
+++ b/src/main/java/InfrastructureManager/Rest/RestRunner.java
@@ -5,22 +5,22 @@ import spark.Spark;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.ArrayList;
 
 public class RestRunner extends Runner {
-    private int port = 4567;
-    private int retryAttempt = 10;
-    private String host = "localhost";
-    private String heartbeatPath = "/heartbeat";
-    private static RestRouter server = null;
+    private final int port;
+    private final int retryAttempt = 10;
+    private final String host = "localhost";
+    private final String heartbeatPath = "/heartbeat";
+    private RestRouter server = null;
     private static RestRunner restRunner = null;
 
-    private RestRunner(String name, MasterInput input, MasterOutput...outputs) {
-        super(name,input,outputs);
+    private RestRunner(String name,int port) {
+        super(name);
+        this.port = port;
     }
 
     private void startServer() {
-        this.server = RestRouter.startRouter(port);
+        this.server = RestRouter.startRouter(this.port);
     }
 
     /**
@@ -86,9 +86,9 @@ public class RestRunner extends Runner {
     /**
      * Method for getting the Singleton REST Runner instance or set from parameter if not available
      */
-    public static RestRunner getRestRunner(String name, MasterInput input, MasterOutput...outputs) {
+    public static RestRunner getRestRunner(String name, int port) {
         if(restRunner == null) {
-            restRunner = new RestRunner(name,input,outputs);
+            restRunner = new RestRunner(name, port);
         }
         return restRunner;
     }
@@ -100,7 +100,7 @@ public class RestRunner extends Runner {
         } catch (Exception e) {
             e.printStackTrace();
         }
-        super.run();
+        running = true;
     }
 
     @Override

--- a/src/main/java/InfrastructureManager/Runner.java
+++ b/src/main/java/InfrastructureManager/Runner.java
@@ -81,7 +81,9 @@ public class Runner implements Runnable{
                 output.out(mapping);
             }
         } catch (Exception e) {
-           // e.printStackTrace();
+           if (!e.getMessage().equals("No command exception")) {
+               e.printStackTrace();
+           }
         }
     }
 

--- a/src/main/java/InfrastructureManager/Runner.java
+++ b/src/main/java/InfrastructureManager/Runner.java
@@ -16,6 +16,14 @@ public class Runner implements Runnable{
     protected volatile boolean running = false; //Flag to see runner status
 
     /**
+     * Constructor of the class, for runners with no inputs or outputs
+     * @param name Name of the runner
+     */
+    public Runner(String name) {
+        this.name = name;
+    }
+
+    /**
      * Constructor of the class, normally configured based on raw data (RunnerConfigData) by the
      * MasterConfigurator
      * @param name Name of the runner
@@ -23,7 +31,7 @@ public class Runner implements Runnable{
      * @param outputs 1 or more MasterOutput objects to be defined as outputs of the runner
      */
     public Runner(String name,MasterInput input, MasterOutput...outputs) {
-        this.name = name;
+        this(name);
         this.input = input;
         this.outputs = outputs;
     }
@@ -73,7 +81,7 @@ public class Runner implements Runnable{
                 output.out(mapping);
             }
         } catch (Exception e) {
-            e.printStackTrace();
+           // e.printStackTrace();
         }
     }
 

--- a/src/main/resources/Configuration.json
+++ b/src/main/resources/Configuration.json
@@ -13,10 +13,10 @@
       "outputs" : ["console"]
     },
     {
-      "name" : "Rest",
+      "name" : "RestServer",
       "scenario" : false,
-      "input" : "rest",
-      "outputs" : ["rest"]
+      "input" : "port4567",
+      "outputs" : [""]
     }
   ],
   "commands" : {

--- a/src/main/resources/Configuration.json
+++ b/src/main/resources/Configuration.json
@@ -3,8 +3,14 @@
     {
       "name" : "Main",
       "scenario" : false,
+      "input" : "console",
+      "outputs" : ["console", "util","scenario editor","scenario dispatcher", "rest"]
+    },
+    {
+      "name" : "RestInputTest",
+      "scenario" : false,
       "input" : "rest",
-      "outputs" : ["console", "util","scenario editor","scenario dispatcher"]
+      "outputs" : ["console", "util"]
     },
     {
       "name" : "Dummy Scenario",
@@ -21,6 +27,8 @@
   ],
   "commands" : {
     "exit" : "util exit",
+    "start_rest_server" : "util runRunner RestServer",
+    "start_runner" : "util runRunner",
     "deploy_application" : "console helmChartExecution" ,
     "node_request" : "console matchMakingExecution" ,
     "update_gui" : "console GUIUpdateExecution" ,

--- a/src/main/resources/Configuration.json
+++ b/src/main/resources/Configuration.json
@@ -3,7 +3,7 @@
     {
       "name" : "Main",
       "scenario" : false,
-      "input" : "console",
+      "input" : "rest",
       "outputs" : ["console", "util","scenario editor","scenario dispatcher"]
     },
     {


### PR DESCRIPTION
I fixed some issues in the REST implementation. Here is the changes I made:

- Now the server is an independent runner, with no inputs or outputs which runs in the background. Given that it uses static callbacks anyway, they werent needed. Instead, now in the configuration file, the port for the server can be defined

- The program can now be run from console without exceptions popping up because of the RestInput

 - Rest input and output are now connected to the master, in the sense that a request to the master will now actually execute a command for example.

- The master can now run any runnable by its name, including the RestServer. A command was made specifically with this purpose, and another one for other runners (RestInputTest for example).

With this working base, I will now get to work on the cgroups issue. 

