### PR TITLE
Multiple Outputs Fix

### DIFF
--- a/src/main/java/InfrastructureManager/Runner.java
+++ b/src/main/java/InfrastructureManager/Runner.java
@@ -78,7 +78,11 @@ public class Runner implements Runnable{
         try {
             String mapping = master.execute(input.read());
             for (MasterOutput output : outputs) {
-                output.out(mapping);
+                try {
+                    output.out(mapping);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
             }
         } catch (Exception e) {
            if (!e.getMessage().equals("No command exception")) {


### PR DESCRIPTION
If one input goes to multiple outputs there is a chance that one of the outputs receive an invalid command, in such cases the for loop should not be terminated, instead it should just print the exception and go for the next input.