### PR TITLE
Fix in AdvantEDGE client

### DIFF
--- a/src/main/java/InfrastructureManager/AdvantEdge/AdvantEdgeClient.java
+++ b/src/main/java/InfrastructureManager/AdvantEdge/AdvantEdgeClient.java
@@ -33,6 +33,7 @@ public class AdvantEdgeClient extends MasterOutput {
      * @param response Must be in the way "advantEdge command" and additionally:
      *      *                 - Creating Scenario : Should include the  name of the scenario and the path of the file where the scenario is defined
      *      *                 - Deploy Scenario : Should include the name of the scenario to be deployed
+     *      *                 - Terminate Scenario: Should include the name of the sandbox name
      *      *                 - Network Update : Should include the sandbox name, the element name (which receives the update), element type and network params.
      * @throws IllegalArgumentException If the command is not defined or is missing arguments
      */
@@ -49,7 +50,7 @@ public class AdvantEdgeClient extends MasterOutput {
                         deployAEScenario(command[2]);
                         break;
                     case "terminate" :
-                        terminateAEScenario();
+                        terminateAEScenario(command[2]);
                         break;
                     case "networkUpdate":
                         sendNetworkCharacteristicsUpdateAEScenario(command[2], command[3], command[4], command[5],
@@ -104,7 +105,7 @@ public class AdvantEdgeClient extends MasterOutput {
      * @param name Name of the scenario to be deployed
      */
     private void deployAEScenario(String name) {
-        String requestPath = this.requestPath + "/platform-ctrl/v1/sandboxes";
+        String requestPath = this.requestPath + "/platform-ctrl/v1/sandboxes/sandbox_" + name;
         //String requestPath = "https://postman-echo.com/post/";
         String jsonRequestString = "{\"scenarioName\" : \""+name+"\"}";
 
@@ -135,8 +136,8 @@ public class AdvantEdgeClient extends MasterOutput {
     /**
      * Terminate the current running scenario in AdvantEdge (Using the REST API)
      */
-    private void terminateAEScenario() {
-        String requestPath = this.requestPath + "/sandbox-ctrl/v1/active/";
+    private void terminateAEScenario(String sandboxName) {
+        String requestPath = this.requestPath + "/" + sandboxName + "/sandbox-ctrl/v1/active/";
         //String requestPath = "https://postman-echo.com/delete";
         try {
             HttpRequest request = HttpRequest.newBuilder()

--- a/src/main/resources/Configuration.json
+++ b/src/main/resources/Configuration.json
@@ -43,7 +43,7 @@
       "commands" : {
         "ae_create_scenario $scenario_name $scenario_path" : "advantEdge create $scenario_name $scenario_path",
         "ae_deploy_scenario $scenario_name" : "advantEdge deploy $scenario_name",
-        "ae_terminate_active" : "advantEdge terminate"
+        "ae_terminate_active $sandbox_name" : "advantEdge terminate $sandbox_name"
       }
     },
     {

--- a/src/test/java/InfrastructureManager/AdvantEdge/AdvantEdgeClientTests.java
+++ b/src/test/java/InfrastructureManager/AdvantEdge/AdvantEdgeClientTests.java
@@ -1,6 +1,5 @@
 package InfrastructureManager.AdvantEdge;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -53,7 +52,7 @@ public class AdvantEdgeClientTests {
 
     @Test
     public void deployScenarioRequestTest() throws IOException {
-        String path = "/platform-ctrl/v1/sandboxes";
+        String path = "/platform-ctrl/v1/sandboxes/sandbox_" + scenarioName;
         String jsonTestPath = "src/test/resources/AdvantEdge/deploy-scenario.json";
         client.out("advantEdge deploy " + scenarioName);
 
@@ -78,8 +77,8 @@ public class AdvantEdgeClientTests {
 
     @Test
     public void terminateScenarioRequestTest() {
-        String path = "/sandbox-ctrl/v1/active/";
-        client.out("advantEdge terminate");
+        String path = "/test_sandbox/sandbox-ctrl/v1/active/";
+        client.out("advantEdge terminate test_sandbox");
         verify(deleteRequestedFor(urlEqualTo(path)));
     }
 


### PR DESCRIPTION
While documenting I realized that we had contradictory behavior in `AdvantEdgeClient`:
- The deploy command, created a sandbox (with server generated name) to deploy the scenario
- The networks characteristic expect a sandbox name as a parameter to perform the update
- The terminate command, didnt add the sandbox name as part of the request path like it should

In this fix I did the following:
- Deploy now send a request to the `sandboxes/{name}` path, assuring we know (and can later refer to) the sandbox name. For creating the name automatically the following convention is used: `"sandbox_" + ScenarioName`
- Terminate now expects `$sandbox_name` as a parameter to send its request.
- Modified the testing accordingly