### PR TITLE
Rest simplification fix

### DIFF
--- a/src/main/java/InfrastructureManager/Rest/RestInput.java
+++ b/src/main/java/InfrastructureManager/Rest/RestInput.java
@@ -11,14 +11,6 @@ public class RestInput implements MasterInput {
     private static String command = "";
     private static ObjectMapper mapper = new ObjectMapper();
 
-    /**
-     * Execute route for POST request that only sends one way data to the Master
-     * Returns true if the request is succesful with code 200
-     */
-    public static Route executeCommand = (Request request, Response response) -> {
-        command = request.params(":command").replaceAll("\\s+","");
-        return response.status();
-    };
 
     public static Route registerClient = (Request request, Response response) -> {
         String clientAsString = request.body().replaceAll("\\s+","");

--- a/src/main/java/InfrastructureManager/Rest/RestInput.java
+++ b/src/main/java/InfrastructureManager/Rest/RestInput.java
@@ -11,8 +11,6 @@ public class RestInput implements MasterInput {
     private static String command = "";
     private static ObjectMapper mapper = new ObjectMapper();
 
-    public static Route readParameterTest = (Request request, Response response) -> request.params(":input");
-
     /**
      * Execute route for POST request that only sends one way data to the Master
      * Returns true if the request is succesful with code 200

--- a/src/main/java/InfrastructureManager/Rest/RestOutput.java
+++ b/src/main/java/InfrastructureManager/Rest/RestOutput.java
@@ -38,15 +38,6 @@ public class RestOutput extends MasterOutput {
         this.limitNodes = new LinkedHashMap<>();
         this.nodesToSend = new HashMap<>();
     }
-    public ObjectNode printResponse() {
-        ObjectNode response_body = mapper.createObjectNode();
-        if(output.isEmpty()) {
-            response_body.put("content", "");
-        } else {
-            response_body.put("content", output.remove());
-        }
-        return response_body;
-    }
 
     public String getLimitInfo(Response response) {
         response.type("application/json");

--- a/src/main/java/InfrastructureManager/Rest/RestRouter.java
+++ b/src/main/java/InfrastructureManager/Rest/RestRouter.java
@@ -11,22 +11,16 @@ public class RestRouter {
         try {
             before("/*", AuthenticationManager.authenticate);
             path("/node", () -> {
-                path("/test", () -> {
-                    post("/read/:input", RestInput.readParameterTest);
-                });
                 post("/execute/:command", RestInput.executeCommand);
                 post("/register", RestInput.registerNode);
+                get("/limit", RestOutput.getInstance().sendLimitInfo);
             });
             path("/client", () -> {
                 post("/register", RestInput.registerClient);
                 post("/assign/:client_id", RestInput.assignClient);
-                try {
-                    get("/get_node/:client_id", RestOutput.getInstance().sendNodeInfo);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
+                get("/get_node/:client_id", RestOutput.getInstance().sendNodeInfo);
             });
-            get("/limit", RestOutput.getInstance().sendLimitInfo);
+
             get("/heartbeat", (request, response) -> {
                 return response.status();
             });

--- a/src/main/java/InfrastructureManager/Rest/RestRouter.java
+++ b/src/main/java/InfrastructureManager/Rest/RestRouter.java
@@ -11,7 +11,6 @@ public class RestRouter {
         try {
             before("/*", AuthenticationManager.authenticate);
             path("/node", () -> {
-                post("/execute/:command", RestInput.executeCommand);
                 post("/register", RestInput.registerNode);
                 get("/limit", RestOutput.getInstance().sendLimitInfo);
             });

--- a/src/main/resources/Configuration.json
+++ b/src/main/resources/Configuration.json
@@ -69,14 +69,6 @@
     },
     {
       "in" : "rest_in",
-      "out" : "util",
-      "commands" : {
-        "exit" : "util exit",
-        "start_runner $runnerName" : "util runRunner $runnerName"
-      }
-    },
-    {
-      "in" : "rest_in",
       "out" : "match_m",
       "commands" : {
         "register_client $client_as_json_string" : "matchMaker register_client $client_as_json_string",

--- a/src/test/java/InfrastructureManager/NodeLimitTests.java
+++ b/src/test/java/InfrastructureManager/NodeLimitTests.java
@@ -34,7 +34,7 @@ public class NodeLimitTests {
         output.out("restOut limit node1 1.5");
         String expected = "{\"node1\":\"150000_100000\"}";
         String response = given().spec(requestSpec)
-                .when().get("/limit")
+                .when().get("/node/limit")
                 .asString();
         Assert.assertEquals(expected, response);
     }
@@ -44,7 +44,7 @@ public class NodeLimitTests {
         output.out("restOut limit node1 1.5 10000");
         String expected = "{\"node1\":\"15000_10000\"}";
         String response = given().spec(requestSpec)
-                .when().get("/limit")
+                .when().get("/node/limit")
                 .asString();
         Assert.assertEquals(expected, response);
     }
@@ -55,7 +55,7 @@ public class NodeLimitTests {
         output.out("restOut limit node2 0.5");
         String expected = "{\"node1\":\"150000_100000\",\"node2\":\"50000_100000\"}";
         String response = given().spec(requestSpec)
-                .when().get("/limit")
+                .when().get("/node/limit")
                 .asString();
         Assert.assertEquals(expected, response);
     }
@@ -64,7 +64,7 @@ public class NodeLimitTests {
     public void requestWithoutCommandFirstTest() {
         String expected = "{}";
         String response = given().spec(requestSpec)
-                .when().get("/limit")
+                .when().get("/node/limit")
                 .asString();
         Assert.assertEquals(expected, response);
     }

--- a/src/test/java/InfrastructureManager/RestFunctionalTests.java
+++ b/src/test/java/InfrastructureManager/RestFunctionalTests.java
@@ -24,28 +24,16 @@ public class RestFunctionalTests {
         RestRunner.getRestRunner("RestRunner",port).startServerIfNotRunning();
     }
 
-    @Test
-    public void testPostRequest() {
-        String command = "test";
-        String response =
-                given().
-                    spec(requestSpec).
-                    pathParam("input", command).
-                when().
-                    post("/node/test/read/{input}").
-                    asString();
-        Assert.assertEquals(command, response);
-    }
 
     @Test
     public void postSubmissionTest() {
-        String request = "resttest";
         String response =
             given().
-                spec(requestSpec).
-                pathParam("command", request).
+                spec(requestSpec)
+                    .contentType("application/json")
+                    .body("{\"id\":\"client1\"}").
             when().
-                post("/node/execute/{command}").
+                post("/client/register").
                 asString();
         Assert.assertEquals("200", response);
     }


### PR DESCRIPTION
While documenting, I realized we have Rest URI and methods that we dont need anymore.

So in this commits I:
- Got rid of un-used REST routes or methods
- Made `node/limit` the path for cpu limit requests (instead of `/limit`)
- Modified the testing accordingly

Do you agree with my criterion @alyhasansakr ? Or should I just document everything as we have it right now