### PR TITLE
Fix match making algorithm sel

### DIFF
--- a/src/main/java/InfrastructureManager/Configuration/MasterConfigurator.java
+++ b/src/main/java/InfrastructureManager/Configuration/MasterConfigurator.java
@@ -83,7 +83,8 @@ public class MasterConfigurator {
 
     private MasterOutput getOutputFromData(IOConfigData outputData) throws IllegalArgumentException {
         int port = outputData.getPort();
-        switch (outputData.getType()) {
+        String[] type = outputData.getType().split("-");
+        switch (type[0]) {
             case "ConsoleOutput":
                 return new ConsoleOutput(outputData.getName());
             case "MasterUtility" :
@@ -96,7 +97,7 @@ public class MasterConfigurator {
                 RestOutput.setInstanceName(outputData.getName());
                 return RestOutput.getInstance();
             case "MatchMaker" :
-                return new MatchMaker(outputData.getName());
+                return new MatchMaker(outputData.getName(),type.length > 1 ? type[1] : "random");
             case "AdvantEdgeClient" :
                 return new AdvantEdgeClient(outputData.getName(),port != 0 ? port : 80);
             default:
@@ -106,11 +107,12 @@ public class MasterConfigurator {
 
     private MasterInput getInputFromData(IOConfigData inputData) throws IllegalArgumentException {
         int port = inputData.getPort();
-        switch (inputData.getType()) {
+        String[] type = inputData.getType().split("-");
+        switch (type[0]) {
             case "ConsoleInput":
                 return new ConsoleInput();
             case "MatchMaker":
-                return new MatchMaker(inputData.getName());
+                return new MatchMaker(inputData.getName(),type.length > 1 ? type[1] : "random");
             case "RestInput":
                 RestRunner.getRestRunner("RestServer",port != 0 ? port : 4567);
                 activateRestRunner = true;

--- a/src/main/java/InfrastructureManager/MatchMaking/MatchMaker.java
+++ b/src/main/java/InfrastructureManager/MatchMaking/MatchMaker.java
@@ -20,9 +20,9 @@ public class MatchMaker extends MasterOutput implements MasterInput {
     private final List<EdgeClient> clientList;
     private final Map<EdgeClient,EdgeNode> mapping;
 
-    public MatchMaker(String name) {
+    public MatchMaker(String name, String algorithmType) {
         super(name);
-        this.algorithm = new RandomMatchMaking(); // For now
+        setAlgorithmFromString(algorithmType);
         this.mapper = new ObjectMapper();
 
         this.nodeList = new ArrayList<>();
@@ -30,7 +30,17 @@ public class MatchMaker extends MasterOutput implements MasterInput {
         this.mapping = new HashMap<>();
     }
 
-    public void setAlgorithm(MatchMakingAlgorithm algorithm) {
+    public void setAlgorithmFromString(String algorithmType) {
+        switch (algorithmType.toLowerCase()) {
+            case "random" :
+                setAlgorithm(new RandomMatchMaking());
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid type for MatchMaker");
+        }
+    }
+
+    private void setAlgorithm(MatchMakingAlgorithm algorithm) {
         this.algorithm = algorithm;
     }
 

--- a/src/main/resources/Configuration.json
+++ b/src/main/resources/Configuration.json
@@ -3,7 +3,7 @@
       "inputs": [
         {"type": "ConsoleInput","name": "console_in"},
         {"type": "RestInput","name": "rest_in", "port": 4567},
-        {"type": "MatchMaker","name": "match_m"},
+        {"type": "MatchMaker-Random","name": "match_m"},
         {"type": "Scenario", "name": "dummy"}
       ],
       "outputs": [
@@ -13,7 +13,7 @@
         {"type": "AdvantEdgeClient","name": "advant_e","port" : 10500},
         {"type": "ScenarioDispatcher","name": "scenario_dispatcher"},
         {"type": "ScenarioEditor","name": "scenario_editor"},
-        {"type": "MatchMaker","name": "match_m"}
+        {"type": "MatchMaker-Random","name": "match_m"}
       ]
     },
   "connections" : [

--- a/src/test/java/InfrastructureManager/MatchMaking/MatchMakingTests.java
+++ b/src/test/java/InfrastructureManager/MatchMaking/MatchMakingTests.java
@@ -17,7 +17,7 @@ import java.util.Map;
 import static io.restassured.RestAssured.given;
 
 public class MatchMakingTests {
-    private final MatchMaker matchMaker = new MatchMaker("match_m");
+    private final MatchMaker matchMaker = new MatchMaker("match_m","random");
     private final CommandSet commandSet= new CommandSet();
     private static RequestSpecification requestSpec;
 


### PR DESCRIPTION
Another quick fix I noted while documenting. Im currently doind the "Running Match Making" part and I realized we had no way of defining the algorithm of the matchmaker (although we currently only have random, I am sure we will have more).

So in this fix:
- I modified the `MatchMaker` so it can be created with a specific algorithm type
- Modified the `MasterConfigurator` and the config file to get the algorithm type: In the configuration file,  separation in the type field is now with the "-" character. For example "MatchMaker-Random" in the type field will result in a `MatchMaker` instance with a `RandomMatchMaking` algorithm. However if just "MatchMaker" is passed, it will be created with a `RandomMatchMaking` by default.
- Modified the testing accordingly