### PR TITLE
Fix in AdvantEdgeClient definition

### DIFF
--- a/src/main/java/InfrastructureManager/AdvantEdge/AdvantEdgeClient.java
+++ b/src/main/java/InfrastructureManager/AdvantEdge/AdvantEdgeClient.java
@@ -16,16 +16,16 @@ import java.nio.file.Paths;
 import java.time.Duration;
 
 public class AdvantEdgeClient extends MasterOutput {
-    private String requestPath = "http://localhost"; //The controller API is exposed on port 80 & 443 of the node where AdvantEDGE is deployed.
+    private final String requestPath; //The controller API is exposed on port 80 & 443 of the node where AdvantEDGE is deployed.
     private final HttpClient client = HttpClient.newBuilder()
             .version(HttpClient.Version.HTTP_1_1)
             .followRedirects(HttpClient.Redirect.NORMAL)
             .connectTimeout(Duration.ofSeconds(20))
             .build();
 
-    public AdvantEdgeClient(String name,int port) {
+    public AdvantEdgeClient(String name,String address, int port) {
         super(name);
-        this.requestPath += ":" + port;
+        this.requestPath = address + ":" + port;
     }
 
     /**

--- a/src/main/java/InfrastructureManager/Configuration/MasterConfigurator.java
+++ b/src/main/java/InfrastructureManager/Configuration/MasterConfigurator.java
@@ -99,7 +99,7 @@ public class MasterConfigurator {
             case "MatchMaker" :
                 return new MatchMaker(outputData.getName(),type.length > 1 ? type[1] : "random");
             case "AdvantEdgeClient" :
-                return new AdvantEdgeClient(outputData.getName(),port != 0 ? port : 80);
+                return new AdvantEdgeClient(outputData.getName(),outputData.getAddress() ,port != 0 ? port : 80);
             default:
                 throw new IllegalArgumentException("Invalid output in Configuration");
         }

--- a/src/main/java/InfrastructureManager/Configuration/RawData/IOConfigData.java
+++ b/src/main/java/InfrastructureManager/Configuration/RawData/IOConfigData.java
@@ -4,11 +4,13 @@ public class IOConfigData {
 
     private final String type;
     private final String name;
+    private final String address;
     private final int port;
 
     public IOConfigData() {
         this.type = null;
         this.name = null;
+        this.address = null;
         this.port = 0;
     }
 
@@ -22,5 +24,9 @@ public class IOConfigData {
 
     public int getPort() {
         return port;
+    }
+
+    public String getAddress() {
+        return address;
     }
 }

--- a/src/main/resources/Configuration.json
+++ b/src/main/resources/Configuration.json
@@ -10,7 +10,7 @@
         {"type": "ConsoleOutput","name": "console_out"},
         {"type": "RestOutput","name": "rest_out"},
         {"type": "MasterUtility","name": "util"},
-        {"type": "AdvantEdgeClient","name": "advant_e", "address" : "192.100.21.2", "port" : 10500},
+        {"type": "AdvantEdgeClient","name": "advant_e", "address" : "http://localhost", "port" : 10500},
         {"type": "ScenarioDispatcher","name": "scenario_dispatcher"},
         {"type": "ScenarioEditor","name": "scenario_editor"},
         {"type": "MatchMaker-Random","name": "match_m"}

--- a/src/main/resources/Configuration.json
+++ b/src/main/resources/Configuration.json
@@ -10,7 +10,7 @@
         {"type": "ConsoleOutput","name": "console_out"},
         {"type": "RestOutput","name": "rest_out"},
         {"type": "MasterUtility","name": "util"},
-        {"type": "AdvantEdgeClient","name": "advant_e","port" : 10500},
+        {"type": "AdvantEdgeClient","name": "advant_e", "address" : "192.100.21.2", "port" : 10500},
         {"type": "ScenarioDispatcher","name": "scenario_dispatcher"},
         {"type": "ScenarioEditor","name": "scenario_editor"},
         {"type": "MatchMaker-Random","name": "match_m"}

--- a/src/test/java/InfrastructureManager/AdvantEdge/AdvantEdgeClientTests.java
+++ b/src/test/java/InfrastructureManager/AdvantEdge/AdvantEdgeClientTests.java
@@ -18,7 +18,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 public class AdvantEdgeClientTests {
     private final String scenarioName = "dummy-test";
     private final int portNumber = 10500;
-    private final AdvantEdgeClient client = new AdvantEdgeClient("ae_client",portNumber);
+    private final AdvantEdgeClient client = new AdvantEdgeClient("ae_client","http://localhost",portNumber);
 
     @Rule //Mock server on port 10500
     public WireMockRule rule = new WireMockRule(options().port(portNumber),false);


### PR DESCRIPTION
`AdvantEdgeClient` had a fixed AdvantEDGE deployment address of `http://localhost`. Given that not always that is true, the address should be an input  in the configuration file in the `AdvantEdgeClient`  definition.

In this commits I did exactly that and modified the testing.