### PR TITLE
Fixed sandbox name in AdvantEDGE

### DIFF
--- a/src/main/java/InfrastructureManager/AdvantEdge/AdvantEdgeClient.java
+++ b/src/main/java/InfrastructureManager/AdvantEdge/AdvantEdgeClient.java
@@ -105,7 +105,7 @@ public class AdvantEdgeClient extends MasterOutput {
      * @param name Name of the scenario to be deployed
      */
     private void deployAEScenario(String name) {
-        String requestPath = this.requestPath + "/platform-ctrl/v1/sandboxes/sandbox_" + name;
+        String requestPath = this.requestPath + "/platform-ctrl/v1/sandboxes/sandbox-" + name;
         //String requestPath = "https://postman-echo.com/post/";
         String jsonRequestString = "{\"scenarioName\" : \""+name+"\"}";
 

--- a/src/test/java/InfrastructureManager/AdvantEdge/AdvantEdgeClientTests.java
+++ b/src/test/java/InfrastructureManager/AdvantEdge/AdvantEdgeClientTests.java
@@ -52,7 +52,7 @@ public class AdvantEdgeClientTests {
 
     @Test
     public void deployScenarioRequestTest() throws IOException {
-        String path = "/platform-ctrl/v1/sandboxes/sandbox_" + scenarioName;
+        String path = "/platform-ctrl/v1/sandboxes/sandbox-" + scenarioName;
         String jsonTestPath = "src/test/resources/AdvantEdge/deploy-scenario.json";
         client.out("advantEdge deploy " + scenarioName);
 


### PR DESCRIPTION
This is a fix on my fix. In the current code, whenever an AdvantEDGE scenario is deployed, the client assing automatically a name for the sandbox with the following format: `sandbox_$SCENARIO_NAME`. However, I just noted that AdvantEDGE doesnt allow "_" as part of a sandbox name, so I changed it to "-".

Now for example, for a scenario called `dummy` the sandbox will be `sandbox-dummy`