### PR TITLE
Gradle Deprecated Code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,15 +41,11 @@ dependencies {
     implementation 'com.sparkjava:spark-core:2.9.2'
     implementation files('libraries/opencv/opencv-450.jar')
     implementation 'com.jcraft:jsch:0.1.55'
+    implementation 'org.slf4j:slf4j-api:1.7.30'
+    implementation 'ch.qos.logback:logback-classic:1.2.3'
+    implementation 'ch.qos.logback:logback-core:1.2.3'
+
     testImplementation 'io.rest-assured:rest-assured:4.3.1'
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.github.tomakehurst:wiremock-jre8:2.27.2'
-
-    //Dependencies for slf4j, for logging purpose
-    // https://mvnrepository.com/artifact/org.slf4j/slf4j-api
-    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.30'
-// https://mvnrepository.com/artifact/ch.qos.logback/logback-classic
-    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
-// https://mvnrepository.com/artifact/ch.qos.logback/logback-core
-    compile group: 'ch.qos.logback', name: 'logback-core', version: '1.2.3'
 }


### PR DESCRIPTION
While documenting, I realized when running from console, gradle was throwing a warning about deprecated code. It was due to the way the logging dependencies were defined and I corrected it, so if someone tries to use the platform, the warning doesnt appear anymore. 