### PR TITLE
Hot fix scenario issue

### DIFF
--- a/src/main/java/InfrastructureManager/ModuleManagement/ModuleInput.java
+++ b/src/main/java/InfrastructureManager/ModuleManagement/ModuleInput.java
@@ -8,15 +8,11 @@ public abstract class ModuleInput {
 
     private final String name;
     private Runner runner;
-    private PlatformModule ownerModule;
+    private final PlatformModule ownerModule;
 
     public ModuleInput(PlatformModule ownerModule,String name) {
         this.ownerModule = ownerModule;
         this.name = name;
-    }
-
-    protected void setOwnerModule(PlatformModule ownerModule) {
-        this.ownerModule = ownerModule;
     }
 
     protected PlatformModule getOwnerModule() {

--- a/src/main/java/InfrastructureManager/Modules/Scenario/Scenario.java
+++ b/src/main/java/InfrastructureManager/Modules/Scenario/Scenario.java
@@ -5,6 +5,7 @@ import InfrastructureManager.ModuleManagement.ModuleInput;
 import InfrastructureManager.ModuleManagement.PlatformModule;
 import InfrastructureManager.Modules.Scenario.Exception.Input.InvalidTimeException;
 import InfrastructureManager.Modules.Scenario.Exception.Input.OwnerModuleNotSetUpException;
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -31,8 +32,8 @@ public class Scenario extends ModuleInput {
      * Constructor of the class
      * @param name Name of the new scenario
      */
-    public Scenario(@JsonProperty("name") String name) {
-        super(null,name + ".scenario");
+    public Scenario(@JacksonInject PlatformModule module, @JsonProperty("name") String name) {
+        super(module,name + ".scenario");
         this.eventList = new ArrayList<>();
         this.startBlock = new Semaphore(0);
         this.startTime = 0; //When a new scenario is created for file or command, start time in 0 (It will be rewritten when is run)
@@ -108,10 +109,6 @@ public class Scenario extends ModuleInput {
      */
     public void deleteEvent(int index) {
         this.eventList.remove(index);
-    }
-
-    public void setOwnerModule(PlatformModule module) {
-        super.setOwnerModule(module);
     }
 
     public void start() throws OwnerModuleNotSetUpException {

--- a/src/main/java/InfrastructureManager/Modules/Scenario/Scenario.java
+++ b/src/main/java/InfrastructureManager/Modules/Scenario/Scenario.java
@@ -7,7 +7,6 @@ import InfrastructureManager.Modules.Scenario.Exception.Input.InvalidTimeExcepti
 import InfrastructureManager.Modules.Scenario.Exception.Input.OwnerModuleNotSetUpException;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,10 +29,10 @@ public class Scenario extends ModuleInput {
 
     /**
      * Constructor of the class
-     * @param name Name of the new scenario
+     *
      */
-    public Scenario(@JacksonInject PlatformModule module, @JsonProperty("name") String name) {
-        super(module,name + ".scenario");
+    public Scenario(@JacksonInject PlatformModule module) {
+        super(module, module.getName() + ".scenario");
         this.eventList = new ArrayList<>();
         this.startBlock = new Semaphore(0);
         this.startTime = 0; //When a new scenario is created for file or command, start time in 0 (It will be rewritten when is run)

--- a/src/main/java/InfrastructureManager/Modules/Scenario/ScenarioEditor.java
+++ b/src/main/java/InfrastructureManager/Modules/Scenario/ScenarioEditor.java
@@ -67,7 +67,7 @@ public class ScenarioEditor extends ModuleOutput {
      * @param name Name of the scenario to be created
      */
     private void create(String name){
-        scenario = new Scenario(name);
+        scenario = new Scenario(this.getOwnerModule(),name);
     }
 
     /**

--- a/src/main/java/InfrastructureManager/Modules/Scenario/ScenarioEditor.java
+++ b/src/main/java/InfrastructureManager/Modules/Scenario/ScenarioEditor.java
@@ -5,6 +5,7 @@ import InfrastructureManager.ModuleManagement.PlatformModule;
 import InfrastructureManager.Modules.Scenario.Exception.Output.EmptyEventListException;
 import InfrastructureManager.Modules.Scenario.Exception.Output.ScenarioEditorException;
 import InfrastructureManager.Modules.Scenario.Exception.Output.ScenarioIOException;
+import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
@@ -26,8 +27,11 @@ public class ScenarioEditor extends ModuleOutput {
 
     public ScenarioEditor(PlatformModule module, String name) {
         super(module,name);
+        InjectableValues inject = new InjectableValues.Std()
+                .addValue(PlatformModule.class, module);
         //When saving to a file, make so the JSON string is indented and "pretty"
         this.mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+        this.mapper.setInjectableValues(inject);
     }
 
     /**
@@ -47,7 +51,7 @@ public class ScenarioEditor extends ModuleOutput {
         if (command[0].equals("editor")) {
             try {
                 switch (command[1]) {
-                    case "create" -> create(command[2]);
+                    case "create" -> create();
                     case "addEvent" -> addEvent(command[2], Integer.parseInt(command[3]));
                     case "deleteEvent" -> deleteLastEvent();
                     case "toFile" -> scenarioToFile(command[2]);
@@ -64,10 +68,9 @@ public class ScenarioEditor extends ModuleOutput {
 
     /**
      * Create a new scenario (related to this editor)
-     * @param name Name of the scenario to be created
      */
-    private void create(String name){
-        scenario = new Scenario(this.getOwnerModule(),name);
+    private void create(){
+        scenario = new Scenario(this.getOwnerModule());
     }
 
     /**

--- a/src/main/java/InfrastructureManager/Modules/Scenario/ScenarioModule.java
+++ b/src/main/java/InfrastructureManager/Modules/Scenario/ScenarioModule.java
@@ -5,6 +5,7 @@ import InfrastructureManager.ModuleManagement.RawData.ModuleConfigData;
 import InfrastructureManager.Modules.Scenario.Exception.Input.InvalidTimeException;
 import InfrastructureManager.Modules.Scenario.Exception.Input.OwnerModuleNotSetUpException;
 import InfrastructureManager.Modules.Scenario.RawData.ScenarioModuleConfigData;
+import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.File;
@@ -24,7 +25,6 @@ public class ScenarioModule extends PlatformModule {
         this.setName(castedData.getName());
         try {
             Scenario scenario = scenarioFromFile(castedData.getPath());
-            scenario.setOwnerModule(this);
             setInputs(scenario);
             this.scenario = (Scenario) this.getInputs().get(0);
             setOutputs(new ScenarioEditor(this,this.getName() + ".editor"),
@@ -57,6 +57,9 @@ public class ScenarioModule extends PlatformModule {
 
     private Scenario scenarioFromFile(String path) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
+        InjectableValues inject = new InjectableValues.Std()
+                .addValue(PlatformModule.class, this);
+        mapper.setInjectableValues(inject);
         return mapper.readValue(new File(path),Scenario.class);
     }
 }

--- a/src/main/resources/scenarios/dummy.json
+++ b/src/main/resources/scenarios/dummy.json
@@ -1,5 +1,4 @@
 {
-  "name": "dummy",
   "eventList": [
     {
       "command": "deploy_application",

--- a/src/main/resources/scenarios/dummyScenario.json
+++ b/src/main/resources/scenarios/dummyScenario.json
@@ -1,5 +1,4 @@
 {
-  "name": "dummy",
   "eventList": [
     {
       "command": "start_rest_server",

--- a/src/test/java/InfrastructureManager/Modules/Scenario/InputUnitTests/ScenarioInputTests.java
+++ b/src/test/java/InfrastructureManager/Modules/Scenario/InputUnitTests/ScenarioInputTests.java
@@ -1,11 +1,13 @@
 package InfrastructureManager.Modules.Scenario.InputUnitTests;
 
+import InfrastructureManager.ModuleManagement.PlatformModule;
 import InfrastructureManager.Modules.CommonTestingMethods;
 import InfrastructureManager.Modules.Scenario.Event;
 import InfrastructureManager.Modules.Scenario.Exception.Input.InvalidTimeException;
 import InfrastructureManager.Modules.Scenario.Exception.Input.OwnerModuleNotSetUpException;
 import InfrastructureManager.Modules.Scenario.Scenario;
 import InfrastructureManager.Modules.Scenario.ScenarioModule;
+import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Test;
@@ -22,8 +24,9 @@ public class ScenarioInputTests {
         ObjectMapper mapper = new ObjectMapper();
         String scenarioPath = "src/test/resources/Modules/Scenario/dummyScenario.json";
         ScenarioModule module =new ScenarioModule();
+        InjectableValues inject = new InjectableValues.Std().addValue(PlatformModule.class, module);
+        mapper.setInjectableValues(inject);
         scenario = mapper.readValue(new File(scenarioPath),Scenario.class);
-        scenario.setOwnerModule(module);
     }
 
     @Test

--- a/src/test/java/InfrastructureManager/Modules/Scenario/OutputUnitTests/ScenarioDispatcherTests.java
+++ b/src/test/java/InfrastructureManager/Modules/Scenario/OutputUnitTests/ScenarioDispatcherTests.java
@@ -6,12 +6,14 @@ import InfrastructureManager.ModuleManagement.Exception.Creation.ModuleManagerEx
 import InfrastructureManager.ModuleManagement.Exception.Execution.ModuleExecutionException;
 import InfrastructureManager.ModuleManagement.Exception.Execution.ModuleNotFoundException;
 import InfrastructureManager.ModuleManagement.ModuleManager;
+import InfrastructureManager.ModuleManagement.PlatformModule;
 import InfrastructureManager.Modules.CommonTestingMethods;
 import InfrastructureManager.Modules.Scenario.Event;
 import InfrastructureManager.Modules.Scenario.Exception.Output.ScenarioDispatcherException;
 import InfrastructureManager.Modules.Scenario.Scenario;
 import InfrastructureManager.Modules.Scenario.ScenarioDispatcher;
 import InfrastructureManager.Modules.Scenario.ScenarioModule;
+import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.*;
 
@@ -25,26 +27,28 @@ import java.util.stream.Collectors;
 public class ScenarioDispatcherTests {
 
     private ScenarioDispatcher dispatcher;
-    private final Scenario scenario;
+    private static Scenario scenario;
     static final long WAITING_TIME = 12000; //If events are delayed this has to be modified
     private final ByteArrayOutputStream outContent;
     private static ScenarioModule module = new ScenarioModule();
 
 
-    public ScenarioDispatcherTests() throws IOException {
-        String scenarioPath = "src/test/resources/Modules/Scenario/dummyScenario.json";
-        ObjectMapper mapper = new ObjectMapper();
-        this.scenario = mapper.readValue(new File(scenarioPath), Scenario.class);
+    public ScenarioDispatcherTests() {
         outContent = new ByteArrayOutputStream();
     }
 
     @BeforeClass
-    public static void setUp() throws ConfigurationException, ModuleManagerException, ModuleNotFoundException {
+    public static void setUp() throws ConfigurationException, ModuleManagerException, ModuleNotFoundException, IOException {
         Master.resetInstance();
         Master.getInstance().configure("src/test/resources/Modules/Scenario/ScenarioConfiguration.json");
         ModuleManager manager = Master.getInstance().getManager();
         manager.startAllModules();
         module = findModule(manager);
+        InjectableValues inject = new InjectableValues.Std().addValue(PlatformModule.class, module);
+        String scenarioPath = "src/test/resources/Modules/Scenario/dummyScenario.json";
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setInjectableValues(inject);
+        scenario = mapper.readValue(new File(scenarioPath), Scenario.class);
     }
 
     @Before

--- a/src/test/java/InfrastructureManager/Modules/Scenario/OutputUnitTests/ScenarioEditorTests.java
+++ b/src/test/java/InfrastructureManager/Modules/Scenario/OutputUnitTests/ScenarioEditorTests.java
@@ -1,8 +1,5 @@
 package InfrastructureManager.Modules.Scenario.OutputUnitTests;
 
-import InfrastructureManager.Configuration.Exception.ConfigurationException;
-import InfrastructureManager.Master;
-import InfrastructureManager.ModuleManagement.Exception.Creation.ModuleManagerException;
 import InfrastructureManager.ModuleManagement.Exception.Execution.ModuleExecutionException;
 import InfrastructureManager.Modules.CommonTestingMethods;
 import InfrastructureManager.Modules.Scenario.Event;
@@ -11,7 +8,6 @@ import InfrastructureManager.Modules.Scenario.Exception.Output.ScenarioEditorExc
 import InfrastructureManager.Modules.Scenario.ScenarioEditor;
 import InfrastructureManager.Modules.Scenario.ScenarioModule;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
@@ -21,25 +17,19 @@ import java.util.stream.Collectors;
 public class ScenarioEditorTests {
 
     ScenarioModule module = new ScenarioModule();
-    ScenarioEditor editor = new ScenarioEditor(module,"dummy.editor");
-    final String scenarioName = "test";
-
-    @BeforeClass
-    public static void configureMaster() throws ConfigurationException, ModuleManagerException {
-        Master.resetInstance();
-        Master.getInstance().configure("src/test/resources/Modules/Scenario/ScenarioConfiguration.json");
-        Master.getInstance().getManager().startAllModules();
-    }
+    ScenarioEditor editor = new ScenarioEditor(module,"test_module.editor");
 
     @Test
     public void createScenarioTest() throws ModuleExecutionException {
-        editor.execute("editor create " + scenarioName);
-        Assert.assertEquals(scenarioName + ".scenario", editor.getScenario().getName());
+        module.setName("test_module");
+        editor.execute("editor create");
+        Assert.assertEquals("test_module.scenario", editor.getScenario().getName());
     }
 
     @Test
     public void addFirstEventTest() throws ModuleExecutionException {
-        editor.execute("editor create " + scenarioName);
+        module.setName("test_module");
+        editor.execute("editor create");
         editor.execute("editor addEvent test_event0 1000");
         String expected = "test_event0";
         String result = getConcatenatedEventCommandsInScenario();
@@ -49,7 +39,8 @@ public class ScenarioEditorTests {
 
     @Test
     public void addAnotherEventTest() throws ModuleExecutionException {
-        editor.execute("editor create " + scenarioName);
+        module.setName("test_module");
+        editor.execute("editor create");
         editor.execute("editor addEvent test_event0 1000");
         editor.execute("editor addEvent test_event1 2000");
         String expected = "test_event0" + "test_event1";
@@ -59,7 +50,8 @@ public class ScenarioEditorTests {
 
     @Test
     public void deleteEventTest() throws ModuleExecutionException {
-        editor.execute("editor create " + scenarioName);
+        module.setName("test_module");
+        editor.execute("editor create");
         editor.execute("editor addEvent test_event0 1000");
         editor.execute("editor addEvent test_event1 2000");
         editor.execute("editor deleteEvent");
@@ -70,7 +62,8 @@ public class ScenarioEditorTests {
 
     @Test
     public void deleteEventOnEmptyEventListThrowsException() throws ModuleExecutionException {
-        editor.execute("editor create " + scenarioName);
+        module.setName("test_module");
+        editor.execute("editor create");
         String command = "editor deleteEvent";
         String expected = "Event list is empty!";
         assertExceptionInOutput(EmptyEventListException.class,expected,command);
@@ -78,8 +71,9 @@ public class ScenarioEditorTests {
 
     @Test
     public void saveToFileTest() throws ModuleExecutionException {
-        File scenarioFile = new File("src/test/resources/Modules/Scenario/" + scenarioName + ".json");
-        editor.execute("editor create " + scenarioName);
+        module.setName("test_module");
+        File scenarioFile = new File("src/test/resources/Modules/Scenario/test_module.json");
+        editor.execute("editor create");
         editor.execute("editor addEvent test_event0 1000");
         editor.execute("editor addEvent test_event1 2000");
         editor.execute("editor toFile src/test/resources/Modules/Scenario/");
@@ -106,7 +100,7 @@ public class ScenarioEditorTests {
 
     @Test
     public void incompleteCommandThrowsException() {
-        String command = "editor create";
+        String command = "editor fromFile";
         String expected = "Arguments missing for command " + command + " to ScenarioEditor";
         assertExceptionInOutput(ScenarioEditorException.class, expected, command);
     }

--- a/src/test/resources/Modules/Scenario/dummyScenario.json
+++ b/src/test/resources/Modules/Scenario/dummyScenario.json
@@ -1,5 +1,4 @@
 {
-  "name" : "dummy" ,
   "eventList" : [
     {
       "command" : "deploy_application",


### PR DESCRIPTION
In orded to fix #82 , and allow for a standard way to name scenarios, in this pull request i made the following:

- Used `@JacksonInject` annotation to inject the owner module into the scenario constructor, leaving the need for a setter method afterwards (Scenario was the only case) and allowing the module to be declared final for all inputs. This also allows module information to be accessed in the scenario constructor
- Unified the scenario name definition, by eliminating the `name` field in scenario JSON files and just naming it automatically after the module which creates it (followed by `.scenario`)

So, to be clear, with the new changes, a scenario definition would only be the event list, for example:
```json
{
  "eventList": [
    {
      "command": "deploy_application",
      "executionTime": 1000
    },
    {
      "command": "update_gui",
      "executionTime": 3000
    },
    {
      "command": "node_request",
      "executionTime": 10000
    }
  ]
}
```
I believe naming the module in the configuration path (which also has the path to the scenario file) and the file itself is clear enough