### PR TITLE
Fixed input and output names in match making modules

### DIFF
--- a/src/main/java/InfrastructureManager/Modules/MatchMaking/Naive/MatchMakingNaiveModule.java
+++ b/src/main/java/InfrastructureManager/Modules/MatchMaking/Naive/MatchMakingNaiveModule.java
@@ -20,7 +20,7 @@ public class MatchMakingNaiveModule  extends MatchMakingModule {
         String name = this.getName();
         MatchesList sharedList = this.getSharedList();
         MatchMakingNaiveModuleConfigData castedData = (MatchMakingNaiveModuleConfigData) data;
-        setInputs(new MatchMakerInput(this, name, sharedList));
-        setOutputs(new MatchMakerOutput(this, name, this.getAlgorithm(), sharedList));
+        setInputs(new MatchMakerInput(this, name + ".in", sharedList));
+        setOutputs(new MatchMakerOutput(this, name + ".out", this.getAlgorithm(), sharedList));
     }
 }

--- a/src/main/java/InfrastructureManager/Modules/MatchMaking/Random/MatchMakingRandomModule.java
+++ b/src/main/java/InfrastructureManager/Modules/MatchMaking/Random/MatchMakingRandomModule.java
@@ -21,7 +21,7 @@ public class MatchMakingRandomModule extends MatchMakingModule {
         MatchesList sharedList = this.getSharedList();
         //If something from the data needs to be used to create IOS
         MatchMakingRandomModuleConfigData castedData = (MatchMakingRandomModuleConfigData) data;
-        setInputs(new MatchMakerInput(this, name, sharedList));
-        setOutputs(new MatchMakerOutput(this, name, this.getAlgorithm(), sharedList));
+        setInputs(new MatchMakerInput(this, name + ".in", sharedList));
+        setOutputs(new MatchMakerOutput(this, name + ".out", this.getAlgorithm(), sharedList));
     }
 }

--- a/src/main/java/InfrastructureManager/Modules/MatchMaking/ScoreBased/MatchMakingScoreBasedModule.java
+++ b/src/main/java/InfrastructureManager/Modules/MatchMaking/ScoreBased/MatchMakingScoreBasedModule.java
@@ -20,7 +20,7 @@ public class MatchMakingScoreBasedModule  extends MatchMakingModule {
         String name = this.getName();
         MatchesList sharedList = this.getSharedList();
         MatchMakingScoreBasedModuleConfigData castedData = (MatchMakingScoreBasedModuleConfigData) data;
-        setInputs(new MatchMakerInput(this, name, sharedList));
-        setOutputs(new MatchMakerOutput(this, name, this.getAlgorithm(), sharedList));
+        setInputs(new MatchMakerInput(this, name + ".in", sharedList));
+        setOutputs(new MatchMakerOutput(this, name + ".out", this.getAlgorithm(), sharedList));
     }
 }


### PR DESCRIPTION
Request to fix #87 .Inputs and outputs in the new Match Making modules, were not name correctly so creating connections to it threw exceptions. 