### PR TITLE
Fixed Jackson ignore annotation to obtain correct Scenario serializing

### DIFF
--- a/src/main/java/InfrastructureManager/ModuleManagement/PlatformInput.java
+++ b/src/main/java/InfrastructureManager/ModuleManagement/PlatformInput.java
@@ -4,7 +4,6 @@ import InfrastructureManager.ModuleManagement.Exception.Execution.ModuleExecutio
 import InfrastructureManager.PlatformObject;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-@JsonIgnoreProperties({"runner", "ownerModule"})
 public abstract class PlatformInput extends PlatformObject {
 
     private final String name;

--- a/src/main/java/InfrastructureManager/Modules/Scenario/Scenario.java
+++ b/src/main/java/InfrastructureManager/Modules/Scenario/Scenario.java
@@ -15,7 +15,8 @@ import java.util.concurrent.Semaphore;
 /**
  * Class representing an scenario, as an object with a name and a list of events
  */
-@JsonIgnoreProperties({"startBlock","startTime","current", "pausedTime", "resumedTime","started"})
+@JsonIgnoreProperties({"startBlock","startTime","currentIndex", "pausedTime",
+        "resumedTime","started", "name", "runner", "ownerModule"})
 public class Scenario extends PlatformInput {
 
     private final List<Event> eventList;


### PR DESCRIPTION
Fixes #89 .

Jackson was not ignoring the `runner` and `ownerModule`properties inherited in `Scenario` from `PlatformInput` and `PlatformObject` so it was trying to serialize those objects as well, when serializing a `Scenario`

Fixed it by adding them to the `@JsonIgnoreProperties` annotation