### PR TITLE
Hot fix shared resources

### DIFF
--- a/src/main/java/InfrastructureManager/ModuleManagement/GlobalVarAccessPlatformModule.java
+++ b/src/main/java/InfrastructureManager/ModuleManagement/GlobalVarAccessPlatformModule.java
@@ -1,0 +1,5 @@
+package InfrastructureManager.ModuleManagement;
+
+public interface GlobalVarAccessPlatformModule {
+    public ModuleSharedResource getResource(String resourceName);
+}

--- a/src/main/java/InfrastructureManager/ModuleManagement/GlobalVarAccessPlatformModule.java
+++ b/src/main/java/InfrastructureManager/ModuleManagement/GlobalVarAccessPlatformModule.java
@@ -1,5 +1,0 @@
-package InfrastructureManager.ModuleManagement;
-
-public interface GlobalVarAccessPlatformModule {
-    public ModuleSharedResource getResource(String resourceName);
-}

--- a/src/main/java/InfrastructureManager/ModuleManagement/ImmutablePlatformModule.java
+++ b/src/main/java/InfrastructureManager/ModuleManagement/ImmutablePlatformModule.java
@@ -2,51 +2,21 @@ package InfrastructureManager.ModuleManagement;
 
 import InfrastructureManager.ModuleManagement.RawData.ModuleConfigData;
 
-import java.util.*;
+import java.util.List;
+import java.util.Map;
 
-public abstract class ImmutablePlatformModule {
-    public enum ModuleState { INITIAL, PAUSED, RUNNING }
+public interface ImmutablePlatformModule {
+    void configure(ModuleConfigData data);
 
-    protected final List<PlatformInput> inputs;
-    protected final List<PlatformOutput> outputs;
-    protected final Map<String, List<Connection>> inputConnections;
-    protected String name;
-    protected ModuleDebugInput debugInput;
-    protected volatile ModuleState state;
+    List<PlatformInput> getInputs();
 
+    List<PlatformOutput> getOutputs();
 
-    public ImmutablePlatformModule() {
-        this.state = ModuleState.INITIAL;
-        this.inputs = new ArrayList<>();
-        this.outputs = new ArrayList<>();
-        this.inputConnections = new HashMap<>();
-    }
+    String getName();
 
-    public abstract void configure(ModuleConfigData data);
+    PlatformModule.ModuleState getState();
 
-    public List<PlatformInput> getInputs() {
-        return Collections.unmodifiableList(inputs);
-    }
+    Map<String, List<Connection>> getInputConnections();
 
-    public List<PlatformOutput> getOutputs() {
-        return Collections.unmodifiableList(outputs);
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public ModuleState getState() {
-        return state;
-    }
-
-    protected Map<String, List<Connection>> getInputConnections() {
-        return Collections.unmodifiableMap(inputConnections);
-    }
-
-    public ModuleDebugInput getDebugInput() {
-        return debugInput;
-    }
-
-
+    ModuleDebugInput getDebugInput();
 }

--- a/src/main/java/InfrastructureManager/ModuleManagement/ModuleDebugInput.java
+++ b/src/main/java/InfrastructureManager/ModuleManagement/ModuleDebugInput.java
@@ -1,11 +1,12 @@
 package InfrastructureManager.ModuleManagement;
 
 import InfrastructureManager.ModuleManagement.Exception.Execution.ModuleExecutionException;
+import InfrastructureManager.PlatformObject;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 
-public class ModuleDebugInput extends PlatformInput {
+public class ModuleDebugInput extends PlatformObject implements PlatformInput {
 
     private final BlockingQueue<String> debugData;
 

--- a/src/main/java/InfrastructureManager/ModuleManagement/ModuleFactory.java
+++ b/src/main/java/InfrastructureManager/ModuleManagement/ModuleFactory.java
@@ -4,15 +4,14 @@ import InfrastructureManager.ModuleManagement.Exception.Creation.ModuleNotDefine
 import InfrastructureManager.ModuleManagement.RawData.ModuleConfigData;
 import InfrastructureManager.Modules.AdvantEDGE.AdvantEdgeModule;
 import InfrastructureManager.Modules.Console.ConsoleModule;
-import InfrastructureManager.Modules.MatchMaking.MatchMakingModule;
 import InfrastructureManager.Modules.MatchMaking.Naive.MatchMakingNaiveModule;
 import InfrastructureManager.Modules.MatchMaking.Random.MatchMakingRandomModule;
 import InfrastructureManager.Modules.MatchMaking.ScoreBased.MatchMakingScoreBasedModule;
+import InfrastructureManager.Modules.NetworkStructure.NetworkModule;
 import InfrastructureManager.Modules.REST.RESTModule;
 import InfrastructureManager.Modules.RemoteExecution.RemoteExecutionModule;
 import InfrastructureManager.Modules.Scenario.ScenarioModule;
 import InfrastructureManager.Modules.Utility.UtilityModule;
-import InfrastructureManager.Modules.NetworkStructure.NetworkModule;
 
 public class ModuleFactory {
 

--- a/src/main/java/InfrastructureManager/ModuleManagement/ModuleSharedResource.java
+++ b/src/main/java/InfrastructureManager/ModuleManagement/ModuleSharedResource.java
@@ -1,0 +1,5 @@
+package InfrastructureManager.ModuleManagement;
+
+public interface ModuleSharedResource {
+    void modify(String... data);
+}

--- a/src/main/java/InfrastructureManager/ModuleManagement/ModuleSharedResource.java
+++ b/src/main/java/InfrastructureManager/ModuleManagement/ModuleSharedResource.java
@@ -1,5 +1,0 @@
-package InfrastructureManager.ModuleManagement;
-
-public interface ModuleSharedResource {
-    void modify(String... data);
-}

--- a/src/main/java/InfrastructureManager/ModuleManagement/PlatformInput.java
+++ b/src/main/java/InfrastructureManager/ModuleManagement/PlatformInput.java
@@ -4,28 +4,11 @@ import InfrastructureManager.ModuleManagement.Exception.Execution.ModuleExecutio
 import InfrastructureManager.PlatformObject;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-public abstract class PlatformInput extends PlatformObject {
+public interface PlatformInput {
 
-    private final String name;
-    private Runner runner;
+    String getName();
+    String read() throws InterruptedException;
+    void response(ModuleExecutionException outputException);
 
-    public PlatformInput(ImmutablePlatformModule ownerModule, String name) {
-        super(ownerModule);
-        this.name = name;
-    }
 
-    public void setRunner(Runner runner) {
-        this.runner = runner;
-    }
-
-    public Runner getRunner() {
-        return runner;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public abstract String read() throws InterruptedException;
-    public abstract void response(ModuleExecutionException outputException);
 }

--- a/src/main/java/InfrastructureManager/ModuleManagement/PlatformModule.java
+++ b/src/main/java/InfrastructureManager/ModuleManagement/PlatformModule.java
@@ -10,7 +10,7 @@ import InfrastructureManager.ModuleManagement.RawData.ModuleConfigData;
 
 import java.util.*;
 
-public abstract class PlatformModule implements ImmutablePlatformModule {
+public abstract class PlatformModule implements ImmutablePlatformModule, GlobalVarAccessPlatformModule {
 
     public enum ModuleState { INITIAL, PAUSED, RUNNING }
 
@@ -23,6 +23,8 @@ public abstract class PlatformModule implements ImmutablePlatformModule {
 
     private final List<Runner> inputRunners;
     private final List<Thread> inputRunnerThreads;
+
+    private final Map<String, ModuleSharedResource> globalVariables;
 
     protected RunnerOperation runnerOperation = (runner,input) -> {
         try {
@@ -56,6 +58,7 @@ public abstract class PlatformModule implements ImmutablePlatformModule {
         this.inputConnections = new HashMap<>();
         this.inputRunners = new ArrayList<>();
         this.inputRunnerThreads = new ArrayList<>();
+        this.globalVariables = new HashMap<>();
     }
 
     public abstract void configure(ModuleConfigData data);
@@ -88,6 +91,15 @@ public abstract class PlatformModule implements ImmutablePlatformModule {
     @Override
     public ModuleDebugInput getDebugInput() {
         return debugInput;
+    }
+
+    @Override
+    public ModuleSharedResource getResource(String resourceName) {
+        return this.globalVariables.get(resourceName);
+    }
+
+    public void addGlobalVariable(String resourceName,ModuleSharedResource resource) {
+        this.globalVariables.put(resourceName, resource);
     }
 
     public void setName(String name) {

--- a/src/main/java/InfrastructureManager/ModuleManagement/PlatformModule.java
+++ b/src/main/java/InfrastructureManager/ModuleManagement/PlatformModule.java
@@ -14,12 +14,12 @@ public abstract class PlatformModule implements ImmutablePlatformModule {
 
     public enum ModuleState { INITIAL, PAUSED, RUNNING }
 
-    protected final List<PlatformInput> inputs;
-    protected final List<PlatformOutput> outputs;
-    protected final Map<String, List<Connection>> inputConnections;
-    protected String name;
-    protected ModuleDebugInput debugInput;
-    protected volatile ModuleState state;
+    private final List<PlatformInput> inputs;
+    private final List<PlatformOutput> outputs;
+    private final Map<String, List<Connection>> inputConnections;
+    private String name;
+    private ModuleDebugInput debugInput;
+    private volatile ModuleState state;
 
     private final List<Runner> inputRunners;
     private final List<Thread> inputRunnerThreads;

--- a/src/main/java/InfrastructureManager/ModuleManagement/PlatformModule.java
+++ b/src/main/java/InfrastructureManager/ModuleManagement/PlatformModule.java
@@ -186,4 +186,12 @@ public abstract class PlatformModule implements ImmutablePlatformModule {
     public String processCommand(String fromInput, CommandSet commands) throws ResponseNotDefinedException {
         return commands.getResponse(fromInput);
     }
+
+    protected Runner getRunnerFromInput(String inputName) throws IncorrectInputException {
+        Runner result = this.inputRunnerMap.get(inputName);
+        if (result == null) {
+            throw new IncorrectInputException("Input not defined in module!");
+        }
+        return result;
+    }
 }

--- a/src/main/java/InfrastructureManager/ModuleManagement/PlatformModule.java
+++ b/src/main/java/InfrastructureManager/ModuleManagement/PlatformModule.java
@@ -8,12 +8,18 @@ import InfrastructureManager.ModuleManagement.Exception.Execution.ModulePausedEx
 import InfrastructureManager.ModuleManagement.Exception.Execution.ModuleStoppedException;
 import InfrastructureManager.ModuleManagement.RawData.ModuleConfigData;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
-public abstract class PlatformModule extends ImmutablePlatformModule {
+public abstract class PlatformModule implements ImmutablePlatformModule {
+
+    public enum ModuleState { INITIAL, PAUSED, RUNNING }
+
+    protected final List<PlatformInput> inputs;
+    protected final List<PlatformOutput> outputs;
+    protected final Map<String, List<Connection>> inputConnections;
+    protected String name;
+    protected ModuleDebugInput debugInput;
+    protected volatile ModuleState state;
 
     private final List<Runner> inputRunners;
     private final List<Thread> inputRunnerThreads;
@@ -44,12 +50,45 @@ public abstract class PlatformModule extends ImmutablePlatformModule {
     }; //For other functionalities can be overridden
 
     protected PlatformModule() {
-        super();
+        this.state = ModuleState.INITIAL;
+        this.inputs = new ArrayList<>();
+        this.outputs = new ArrayList<>();
+        this.inputConnections = new HashMap<>();
         this.inputRunners = new ArrayList<>();
         this.inputRunnerThreads = new ArrayList<>();
     }
 
     public abstract void configure(ModuleConfigData data);
+
+    @Override
+    public List<PlatformInput> getInputs() {
+        return Collections.unmodifiableList(inputs);
+    }
+
+    @Override
+    public List<PlatformOutput> getOutputs() {
+        return Collections.unmodifiableList(outputs);
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public ModuleState getState() {
+        return state;
+    }
+
+    @Override
+    public Map<String, List<Connection>> getInputConnections() {
+        return Collections.unmodifiableMap(inputConnections);
+    }
+
+    @Override
+    public ModuleDebugInput getDebugInput() {
+        return debugInput;
+    }
 
     public void setName(String name) {
         this.name = name;

--- a/src/main/java/InfrastructureManager/ModuleManagement/PlatformOutput.java
+++ b/src/main/java/InfrastructureManager/ModuleManagement/PlatformOutput.java
@@ -1,7 +1,7 @@
 package InfrastructureManager.ModuleManagement;
 
 import InfrastructureManager.ModuleManagement.Exception.Execution.ModuleExecutionException;
-import InfrastructureManager.ModuleManagement.ImmutablePlatformModule.ModuleState;
+import InfrastructureManager.ModuleManagement.PlatformModule.ModuleState;
 import InfrastructureManager.PlatformObject;
 
 public abstract class PlatformOutput extends PlatformObject {

--- a/src/main/java/InfrastructureManager/ModuleManagement/PlatformOutput.java
+++ b/src/main/java/InfrastructureManager/ModuleManagement/PlatformOutput.java
@@ -1,24 +1,9 @@
 package InfrastructureManager.ModuleManagement;
 
 import InfrastructureManager.ModuleManagement.Exception.Execution.ModuleExecutionException;
-import InfrastructureManager.ModuleManagement.PlatformModule.ModuleState;
-import InfrastructureManager.PlatformObject;
 
-public abstract class PlatformOutput extends PlatformObject {
-    private final String name;
-
-    public PlatformOutput(ImmutablePlatformModule ownerModule, String name) {
-        super(ownerModule);
-        this.name = name;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public ModuleState getOwnerModuleState() {
-        return this.getOwnerModule().getState();
-    }
-
-    public abstract void execute(String response) throws ModuleExecutionException;
+public interface PlatformOutput{
+    void execute(String response) throws ModuleExecutionException;
+    String getName();
+    PlatformModule.ModuleState getOwnerModuleState();
 }

--- a/src/main/java/InfrastructureManager/Modules/AdvantEDGE/AdvantEdgeModuleObject.java
+++ b/src/main/java/InfrastructureManager/Modules/AdvantEDGE/AdvantEdgeModuleObject.java
@@ -1,0 +1,14 @@
+package InfrastructureManager.Modules.AdvantEDGE;
+
+import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
+import InfrastructureManager.PlatformObject;
+
+public class AdvantEdgeModuleObject extends PlatformObject {
+    public AdvantEdgeModuleObject(ImmutablePlatformModule ownerModule) {
+        super(ownerModule);
+    }
+
+    public AdvantEdgeModuleObject(ImmutablePlatformModule ownerModule, String name) {
+        super(ownerModule, name);
+    }
+}

--- a/src/main/java/InfrastructureManager/Modules/AdvantEDGE/Output/AdvantEdgeClient.java
+++ b/src/main/java/InfrastructureManager/Modules/AdvantEDGE/Output/AdvantEdgeClient.java
@@ -1,12 +1,13 @@
 package InfrastructureManager.Modules.AdvantEDGE.Output;
 
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
+import InfrastructureManager.ModuleManagement.PlatformOutput;
+import InfrastructureManager.Modules.AdvantEDGE.AdvantEdgeModuleObject;
 import InfrastructureManager.Modules.AdvantEDGE.Exception.AdvantEdgeModuleException;
 import InfrastructureManager.Modules.AdvantEDGE.Exception.ErrorInResponseException;
 import InfrastructureManager.Modules.AdvantEDGE.Output.NetworkCharacteristic.NetworkCharacteristicsUpdate;
 import InfrastructureManager.Modules.AdvantEDGE.Output.NetworkCharacteristic.NetworkEvent;
 import InfrastructureManager.Modules.AdvantEDGE.Output.NetworkCharacteristic.NetworkParameters;
-import InfrastructureManager.ModuleManagement.PlatformOutput;
 import InfrastructureManager.Utils.FileParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -19,7 +20,7 @@ import java.net.http.HttpResponse;
 import java.nio.file.Paths;
 import java.time.Duration;
 
-public class AdvantEdgeClient extends PlatformOutput {
+public class AdvantEdgeClient extends AdvantEdgeModuleObject implements PlatformOutput {
     //The controller API is exposed on port 80 & 443 of the node where AdvantEDGE is deployed.
     private final String requestPath;
     private final HttpClient client = HttpClient.newBuilder()

--- a/src/main/java/InfrastructureManager/Modules/Console/ConsoleInput.java
+++ b/src/main/java/InfrastructureManager/Modules/Console/ConsoleInput.java
@@ -9,7 +9,7 @@ import java.util.Scanner;
 /**
  * Class representing input from the console as a form of PlatformInput
  */
-public class ConsoleInput extends PlatformInput {
+public class ConsoleInput extends ConsoleModuleObject implements PlatformInput {
     private final Scanner IN = new Scanner(System.in);
 
     public ConsoleInput(ImmutablePlatformModule module, String name) {

--- a/src/main/java/InfrastructureManager/Modules/Console/ConsoleModuleObject.java
+++ b/src/main/java/InfrastructureManager/Modules/Console/ConsoleModuleObject.java
@@ -1,0 +1,14 @@
+package InfrastructureManager.Modules.Console;
+
+import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
+import InfrastructureManager.PlatformObject;
+
+public class ConsoleModuleObject extends PlatformObject {
+    public ConsoleModuleObject(ImmutablePlatformModule ownerModule) {
+        super(ownerModule);
+    }
+
+    public ConsoleModuleObject(ImmutablePlatformModule ownerModule, String name) {
+        super(ownerModule, name);
+    }
+}

--- a/src/main/java/InfrastructureManager/Modules/Console/ConsoleOutput.java
+++ b/src/main/java/InfrastructureManager/Modules/Console/ConsoleOutput.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 /**
  * Class representing output to the console as a form of MasterOutput
  */
-public class ConsoleOutput extends PlatformOutput {
+public class ConsoleOutput extends ConsoleModuleObject implements PlatformOutput {
 
     public ConsoleOutput(ImmutablePlatformModule module, String name) {
         super(module, name);

--- a/src/main/java/InfrastructureManager/Modules/MatchMaking/Client/EdgeClient.java
+++ b/src/main/java/InfrastructureManager/Modules/MatchMaking/Client/EdgeClient.java
@@ -1,13 +1,14 @@
 package InfrastructureManager.Modules.MatchMaking.Client;
 
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
+import InfrastructureManager.Modules.MatchMaking.MatchMakingModuleObject;
 import InfrastructureManager.PlatformObject;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 import java.util.Objects;
 
-public class EdgeClient extends PlatformObject {
+public class EdgeClient extends MatchMakingModuleObject {
 
     private final String id;
     private long reqResource; //required computation resource

--- a/src/main/java/InfrastructureManager/Modules/MatchMaking/Client/EdgeClientHistory.java
+++ b/src/main/java/InfrastructureManager/Modules/MatchMaking/Client/EdgeClientHistory.java
@@ -3,6 +3,7 @@ package InfrastructureManager.Modules.MatchMaking.Client;
 
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
 import InfrastructureManager.Modules.MatchMaking.Exception.NoNodeFoundInHistoryException;
+import InfrastructureManager.Modules.MatchMaking.MatchMakingModuleObject;
 import InfrastructureManager.PlatformObject;
 
 import java.util.*;
@@ -15,7 +16,7 @@ import java.util.*;
  *
  * @author Zero
  */
-public class EdgeClientHistory extends PlatformObject {
+public class EdgeClientHistory extends MatchMakingModuleObject {
     private String id;
     //multimap with nodeID - history score
     private final HashMap<String, Long> nodeHistoryScoreHash = new HashMap<>();

--- a/src/main/java/InfrastructureManager/Modules/MatchMaking/GlobalVarAccessMMModule.java
+++ b/src/main/java/InfrastructureManager/Modules/MatchMaking/GlobalVarAccessMMModule.java
@@ -2,7 +2,7 @@ package InfrastructureManager.Modules.MatchMaking;
 
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
 
-public interface GlobalVarAccessMMModule extends ImmutablePlatformModule {
+interface GlobalVarAccessMMModule extends ImmutablePlatformModule {
 
     MatchesList getSharedList();
 }

--- a/src/main/java/InfrastructureManager/Modules/MatchMaking/GlobalVarAccessMMModule.java
+++ b/src/main/java/InfrastructureManager/Modules/MatchMaking/GlobalVarAccessMMModule.java
@@ -1,0 +1,8 @@
+package InfrastructureManager.Modules.MatchMaking;
+
+import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
+
+public interface GlobalVarAccessMMModule extends ImmutablePlatformModule {
+
+    MatchesList getSharedList();
+}

--- a/src/main/java/InfrastructureManager/Modules/MatchMaking/Input/MatchMakerInput.java
+++ b/src/main/java/InfrastructureManager/Modules/MatchMaking/Input/MatchMakerInput.java
@@ -3,17 +3,15 @@ package InfrastructureManager.Modules.MatchMaking.Input;
 import InfrastructureManager.ModuleManagement.Exception.Execution.ModuleExecutionException;
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
 import InfrastructureManager.ModuleManagement.PlatformInput;
-import InfrastructureManager.Modules.MatchMaking.MatchesList;
+import InfrastructureManager.Modules.MatchMaking.MatchMakingModuleObject;
 
-public class MatchMakerInput extends PlatformInput {
+public class MatchMakerInput extends MatchMakingModuleObject implements PlatformInput {
 
-    private final MatchesList sharedMatchesList;
     private String toSend;
 
-    public MatchMakerInput(ImmutablePlatformModule module, String name, MatchesList mapping) {
+    public MatchMakerInput(ImmutablePlatformModule module, String name) {
         super(module,name);
         toSend = "";
-        this.sharedMatchesList = mapping;
     }
 
     @Override
@@ -28,6 +26,6 @@ public class MatchMakerInput extends PlatformInput {
     public void response(ModuleExecutionException outputException) {}
 
     private String waitForMatch() throws InterruptedException {
-        return this.sharedMatchesList.getLastAdded();
+        return this.getSharedList().getLastAdded();
     }
 }

--- a/src/main/java/InfrastructureManager/Modules/MatchMaking/MatchMakingModule.java
+++ b/src/main/java/InfrastructureManager/Modules/MatchMaking/MatchMakingModule.java
@@ -3,7 +3,7 @@ package InfrastructureManager.Modules.MatchMaking;
 import InfrastructureManager.ModuleManagement.PlatformModule;
 import InfrastructureManager.ModuleManagement.RawData.ModuleConfigData;
 
-public class MatchMakingModule extends PlatformModule {
+public class MatchMakingModule extends PlatformModule implements GlobalVarAccessMMModule {
 
     private final MatchesList sharedList;
     private MatchMakingAlgorithm algorithm;
@@ -13,7 +13,8 @@ public class MatchMakingModule extends PlatformModule {
         this.sharedList = new MatchesList(this);
     }
 
-    protected MatchesList getSharedList() {
+    @Override
+    public MatchesList getSharedList() {
         return sharedList;
     }
 

--- a/src/main/java/InfrastructureManager/Modules/MatchMaking/MatchMakingModuleObject.java
+++ b/src/main/java/InfrastructureManager/Modules/MatchMaking/MatchMakingModuleObject.java
@@ -1,0 +1,19 @@
+package InfrastructureManager.Modules.MatchMaking;
+
+import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
+import InfrastructureManager.PlatformObject;
+
+public class MatchMakingModuleObject extends PlatformObject {
+    public MatchMakingModuleObject(ImmutablePlatformModule ownerModule) {
+        super(ownerModule);
+    }
+
+    public MatchMakingModuleObject(ImmutablePlatformModule ownerModule, String name) {
+        super(ownerModule, name);
+    }
+
+    public MatchesList getSharedList() {
+        GlobalVarAccessMMModule casted = (GlobalVarAccessMMModule)this.getOwnerModule();
+        return casted.getSharedList();
+    }
+}

--- a/src/main/java/InfrastructureManager/Modules/MatchMaking/MatchMakingModuleObject.java
+++ b/src/main/java/InfrastructureManager/Modules/MatchMaking/MatchMakingModuleObject.java
@@ -2,6 +2,7 @@ package InfrastructureManager.Modules.MatchMaking;
 
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
 import InfrastructureManager.PlatformObject;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public class MatchMakingModuleObject extends PlatformObject {
     public MatchMakingModuleObject(ImmutablePlatformModule ownerModule) {
@@ -12,6 +13,7 @@ public class MatchMakingModuleObject extends PlatformObject {
         super(ownerModule, name);
     }
 
+    @JsonIgnore
     public MatchesList getSharedList() {
         GlobalVarAccessMMModule casted = (GlobalVarAccessMMModule)this.getOwnerModule();
         return casted.getSharedList();

--- a/src/main/java/InfrastructureManager/Modules/MatchMaking/MatchesList.java
+++ b/src/main/java/InfrastructureManager/Modules/MatchMaking/MatchesList.java
@@ -10,7 +10,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Semaphore;
 import java.util.stream.Collectors;
 
-public class MatchesList extends PlatformObject {
+public class MatchesList extends MatchMakingModuleObject {
     private final ConcurrentMap<String, String> matches; //Map Key:CLIENT_ID Value:NODE_JSON
     private final Semaphore block;
     private String lastClientAdded;

--- a/src/main/java/InfrastructureManager/Modules/MatchMaking/Naive/MatchMakingNaiveModule.java
+++ b/src/main/java/InfrastructureManager/Modules/MatchMaking/Naive/MatchMakingNaiveModule.java
@@ -3,7 +3,6 @@ package InfrastructureManager.Modules.MatchMaking.Naive;
 import InfrastructureManager.ModuleManagement.RawData.ModuleConfigData;
 import InfrastructureManager.Modules.MatchMaking.Input.MatchMakerInput;
 import InfrastructureManager.Modules.MatchMaking.MatchMakingModule;
-import InfrastructureManager.Modules.MatchMaking.MatchesList;
 import InfrastructureManager.Modules.MatchMaking.Naive.RawData.MatchMakingNaiveModuleConfigData;
 import InfrastructureManager.Modules.MatchMaking.Output.MatchMakerOutput;
 
@@ -18,9 +17,8 @@ public class MatchMakingNaiveModule  extends MatchMakingModule {
         super.configure(data);
         setAlgorithm(new NaiveMatchMaking(this));
         String name = this.getName();
-        MatchesList sharedList = this.getSharedList();
         MatchMakingNaiveModuleConfigData castedData = (MatchMakingNaiveModuleConfigData) data;
-        setInputs(new MatchMakerInput(this, name + ".in", sharedList));
-        setOutputs(new MatchMakerOutput(this, name + ".out", this.getAlgorithm(), sharedList));
+        setInputs(new MatchMakerInput(this, name + ".in"));
+        setOutputs(new MatchMakerOutput(this, name + ".out", this.getAlgorithm()));
     }
 }

--- a/src/main/java/InfrastructureManager/Modules/MatchMaking/Naive/NaiveMatchMaking.java
+++ b/src/main/java/InfrastructureManager/Modules/MatchMaking/Naive/NaiveMatchMaking.java
@@ -3,6 +3,7 @@ package InfrastructureManager.Modules.MatchMaking.Naive;
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
 import InfrastructureManager.Modules.MatchMaking.MatchMakingAlgorithm;
 import InfrastructureManager.Modules.MatchMaking.Client.EdgeClient;
+import InfrastructureManager.Modules.MatchMaking.MatchMakingModuleObject;
 import InfrastructureManager.Modules.MatchMaking.Node.EdgeNode;
 import InfrastructureManager.Modules.MatchMaking.Exception.NoNodeSatisfyRequirementException;
 import InfrastructureManager.PlatformObject;
@@ -11,7 +12,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
-public class NaiveMatchMaking extends PlatformObject implements MatchMakingAlgorithm {
+public class NaiveMatchMaking extends MatchMakingModuleObject implements MatchMakingAlgorithm {
     private static final long ACCEPTABLE_PING = 300; //use this as parameter before put them in the calculation
     private Logger logger = LoggerFactory.getLogger(this.getClass());
 

--- a/src/main/java/InfrastructureManager/Modules/MatchMaking/Node/EdgeNode.java
+++ b/src/main/java/InfrastructureManager/Modules/MatchMaking/Node/EdgeNode.java
@@ -1,13 +1,14 @@
 package InfrastructureManager.Modules.MatchMaking.Node;
 
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
+import InfrastructureManager.Modules.MatchMaking.MatchMakingModuleObject;
 import InfrastructureManager.PlatformObject;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 import java.util.Objects;
 
-public class EdgeNode extends PlatformObject {
+public class EdgeNode extends MatchMakingModuleObject {
 
     private final String id;
     private String ipAddress;

--- a/src/main/java/InfrastructureManager/Modules/MatchMaking/Output/MatchMakerOutput.java
+++ b/src/main/java/InfrastructureManager/Modules/MatchMaking/Output/MatchMakerOutput.java
@@ -1,6 +1,7 @@
 package InfrastructureManager.Modules.MatchMaking.Output;
 
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
+import InfrastructureManager.ModuleManagement.PlatformModule;
 import InfrastructureManager.ModuleManagement.PlatformOutput;
 import InfrastructureManager.Modules.MatchMaking.Client.EdgeClient;
 import InfrastructureManager.Modules.MatchMaking.Client.EdgeClientHistory;

--- a/src/main/java/InfrastructureManager/Modules/MatchMaking/Output/MatchMakerOutput.java
+++ b/src/main/java/InfrastructureManager/Modules/MatchMaking/Output/MatchMakerOutput.java
@@ -1,12 +1,12 @@
 package InfrastructureManager.Modules.MatchMaking.Output;
 
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
-import InfrastructureManager.ModuleManagement.PlatformModule;
 import InfrastructureManager.ModuleManagement.PlatformOutput;
 import InfrastructureManager.Modules.MatchMaking.Client.EdgeClient;
 import InfrastructureManager.Modules.MatchMaking.Client.EdgeClientHistory;
 import InfrastructureManager.Modules.MatchMaking.Exception.*;
 import InfrastructureManager.Modules.MatchMaking.MatchMakingAlgorithm;
+import InfrastructureManager.Modules.MatchMaking.MatchMakingModuleObject;
 import InfrastructureManager.Modules.MatchMaking.MatchesList;
 import InfrastructureManager.Modules.MatchMaking.Node.EdgeNode;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 
-public class MatchMakerOutput extends PlatformOutput {
+public class MatchMakerOutput extends MatchMakingModuleObject implements PlatformOutput {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final ObjectMapper mapper;
@@ -27,9 +27,9 @@ public class MatchMakerOutput extends PlatformOutput {
     private final List<EdgeNode> nodeList;
     private final List<EdgeClient> clientList;
 
-    public MatchMakerOutput(ImmutablePlatformModule module, String name, MatchMakingAlgorithm algorithm, MatchesList mapping) {
+    public MatchMakerOutput(ImmutablePlatformModule module, String name, MatchMakingAlgorithm algorithm) {
         super(module,name);
-        this.sharedMatchesList = mapping;
+        this.sharedMatchesList = this.getSharedList();
         this.algorithm = algorithm;
         this.mapper = new ObjectMapper();
         this.nodeList = new ArrayList<>();

--- a/src/main/java/InfrastructureManager/Modules/MatchMaking/Random/MatchMakingRandomModule.java
+++ b/src/main/java/InfrastructureManager/Modules/MatchMaking/Random/MatchMakingRandomModule.java
@@ -3,7 +3,6 @@ package InfrastructureManager.Modules.MatchMaking.Random;
 import InfrastructureManager.ModuleManagement.RawData.ModuleConfigData;
 import InfrastructureManager.Modules.MatchMaking.Input.MatchMakerInput;
 import InfrastructureManager.Modules.MatchMaking.MatchMakingModule;
-import InfrastructureManager.Modules.MatchMaking.MatchesList;
 import InfrastructureManager.Modules.MatchMaking.Output.MatchMakerOutput;
 import InfrastructureManager.Modules.MatchMaking.Random.RawData.MatchMakingRandomModuleConfigData;
 
@@ -18,10 +17,9 @@ public class MatchMakingRandomModule extends MatchMakingModule {
         super.configure(data);
         setAlgorithm(new RandomMatchMaking(this));
         String name = this.getName();
-        MatchesList sharedList = this.getSharedList();
         //If something from the data needs to be used to create IOS
         MatchMakingRandomModuleConfigData castedData = (MatchMakingRandomModuleConfigData) data;
-        setInputs(new MatchMakerInput(this, name + ".in", sharedList));
-        setOutputs(new MatchMakerOutput(this, name + ".out", this.getAlgorithm(), sharedList));
+        setInputs(new MatchMakerInput(this, name + ".in"));
+        setOutputs(new MatchMakerOutput(this, name + ".out", this.getAlgorithm()));
     }
 }

--- a/src/main/java/InfrastructureManager/Modules/MatchMaking/Random/RandomMatchMaking.java
+++ b/src/main/java/InfrastructureManager/Modules/MatchMaking/Random/RandomMatchMaking.java
@@ -3,6 +3,7 @@ package InfrastructureManager.Modules.MatchMaking.Random;
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
 import InfrastructureManager.Modules.MatchMaking.MatchMakingAlgorithm;
 import InfrastructureManager.Modules.MatchMaking.Client.EdgeClient;
+import InfrastructureManager.Modules.MatchMaking.MatchMakingModuleObject;
 import InfrastructureManager.Modules.MatchMaking.Node.EdgeNode;
 import InfrastructureManager.PlatformObject;
 import org.slf4j.Logger;
@@ -11,7 +12,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.Random;
 
-public class RandomMatchMaking extends PlatformObject implements MatchMakingAlgorithm {
+public class RandomMatchMaking extends MatchMakingModuleObject implements MatchMakingAlgorithm {
 
     private Logger logger = LoggerFactory.getLogger(this.getClass());
 

--- a/src/main/java/InfrastructureManager/Modules/MatchMaking/ScoreBased/MatchMakingScoreBasedModule.java
+++ b/src/main/java/InfrastructureManager/Modules/MatchMaking/ScoreBased/MatchMakingScoreBasedModule.java
@@ -18,9 +18,8 @@ public class MatchMakingScoreBasedModule  extends MatchMakingModule {
         super.configure(data);
         setAlgorithm(new ScoreBasedMatchMaking(this));
         String name = this.getName();
-        MatchesList sharedList = this.getSharedList();
         MatchMakingScoreBasedModuleConfigData castedData = (MatchMakingScoreBasedModuleConfigData) data;
-        setInputs(new MatchMakerInput(this, name + ".in", sharedList));
-        setOutputs(new MatchMakerOutput(this, name + ".out", this.getAlgorithm(), sharedList));
+        setInputs(new MatchMakerInput(this, name + ".in"));
+        setOutputs(new MatchMakerOutput(this, name + ".out", this.getAlgorithm()));
     }
 }

--- a/src/main/java/InfrastructureManager/Modules/MatchMaking/ScoreBased/ScoreBasedMatchMaking.java
+++ b/src/main/java/InfrastructureManager/Modules/MatchMaking/ScoreBased/ScoreBasedMatchMaking.java
@@ -3,6 +3,7 @@ package InfrastructureManager.Modules.MatchMaking.ScoreBased;
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
 import InfrastructureManager.Modules.MatchMaking.MatchMakingAlgorithm;
 import InfrastructureManager.Modules.MatchMaking.Client.EdgeClient;
+import InfrastructureManager.Modules.MatchMaking.MatchMakingModuleObject;
 import InfrastructureManager.Modules.MatchMaking.Node.EdgeNode;
 import InfrastructureManager.Modules.MatchMaking.Client.EdgeClientHistory;
 import InfrastructureManager.Modules.MatchMaking.Exception.NoNodeFoundInHistoryException;
@@ -20,7 +21,7 @@ import java.util.*;
  *
  * @author Zero
  */
-public class ScoreBasedMatchMaking extends PlatformObject implements MatchMakingAlgorithm {
+public class ScoreBasedMatchMaking extends MatchMakingModuleObject implements MatchMakingAlgorithm {
 
     //TODO: Weight should be dynamic
     private final Logger logger = LoggerFactory.getLogger(this.getClass());

--- a/src/main/java/InfrastructureManager/Modules/NetworkStructure/GlobalVarAccessNetworkModule.java
+++ b/src/main/java/InfrastructureManager/Modules/NetworkStructure/GlobalVarAccessNetworkModule.java
@@ -1,0 +1,7 @@
+package InfrastructureManager.Modules.NetworkStructure;
+
+import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
+
+interface GlobalVarAccessNetworkModule extends ImmutablePlatformModule {
+    String getSharedResource(); //TODO: This is an example of a String shared resource, change the type
+}

--- a/src/main/java/InfrastructureManager/Modules/NetworkStructure/Input/NetworkInput.java
+++ b/src/main/java/InfrastructureManager/Modules/NetworkStructure/Input/NetworkInput.java
@@ -5,8 +5,10 @@ import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
 import InfrastructureManager.ModuleManagement.PlatformInput;
 
 import InfrastructureManager.Modules.NetworkStructure.Network;
+import InfrastructureManager.Modules.NetworkStructure.NetworkModuleObject;
+import InfrastructureManager.PlatformObject;
 
-public class NetworkInput extends PlatformInput {
+public class NetworkInput extends NetworkModuleObject implements PlatformInput {
 	
 	private final Network network;
 	

--- a/src/main/java/InfrastructureManager/Modules/NetworkStructure/NetworkModule.java
+++ b/src/main/java/InfrastructureManager/Modules/NetworkStructure/NetworkModule.java
@@ -7,7 +7,7 @@ import InfrastructureManager.Modules.NetworkStructure.RawData.NetworkModuleConfi
  *
  * @author Shankar Lokeshwara
  */
-public class NetworkModule extends PlatformModule {
+public class NetworkModule extends PlatformModule implements GlobalVarAccessNetworkModule{
 
     public NetworkModule() {
         super();
@@ -15,5 +15,10 @@ public class NetworkModule extends PlatformModule {
     @Override
     public void configure(ModuleConfigData data) {
     	NetworkModuleConfigData castedData = (NetworkModuleConfigData) data;
+    }
+
+    @Override
+    public String getSharedResource() { //TODO: This is an example with a String, change the type accordingly
+        return null;
     }
 }

--- a/src/main/java/InfrastructureManager/Modules/NetworkStructure/NetworkModuleObject.java
+++ b/src/main/java/InfrastructureManager/Modules/NetworkStructure/NetworkModuleObject.java
@@ -1,0 +1,23 @@
+package InfrastructureManager.Modules.NetworkStructure;
+
+import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
+import InfrastructureManager.PlatformObject;
+
+public class NetworkModuleObject extends PlatformObject {
+    public NetworkModuleObject(ImmutablePlatformModule ownerModule) {
+        super(ownerModule);
+    }
+
+    public NetworkModuleObject(ImmutablePlatformModule ownerModule, String name) {
+        super(ownerModule, name);
+    }
+
+    /*
+    TODO: This is an example of a String shared resource, change the type to whatever it is you are sharing,
+     and add more methods like this if sharing more than one thing. Note that it depends on the interface (GlobalVarAccessNetworkModule)
+     */
+    public String getSharedResource() {
+        GlobalVarAccessNetworkModule casted = (GlobalVarAccessNetworkModule) this.getOwnerModule();
+        return casted.getSharedResource();
+    }
+}

--- a/src/main/java/InfrastructureManager/Modules/NetworkStructure/Output/NetworkOutput.java
+++ b/src/main/java/InfrastructureManager/Modules/NetworkStructure/Output/NetworkOutput.java
@@ -2,11 +2,13 @@ package InfrastructureManager.Modules.NetworkStructure.Output;
 
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
 import InfrastructureManager.ModuleManagement.PlatformOutput;
+import InfrastructureManager.Modules.NetworkStructure.NetworkModuleObject;
+import InfrastructureManager.PlatformObject;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import InfrastructureManager.Modules.NetworkStructure.Exception.NetworkModuleException;
 import InfrastructureManager.Modules.NetworkStructure.Network;
 
-public class NetworkOutput extends PlatformOutput {
+public class NetworkOutput extends NetworkModuleObject implements PlatformOutput {
 	private Network network;
 	public NetworkOutput(ImmutablePlatformModule module, String name, Network network) {
 		super(module,name);

--- a/src/main/java/InfrastructureManager/Modules/REST/Input/POSTInput.java
+++ b/src/main/java/InfrastructureManager/Modules/REST/Input/POSTInput.java
@@ -5,6 +5,7 @@ import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
 import InfrastructureManager.ModuleManagement.PlatformInput;
 import InfrastructureManager.Modules.REST.Exception.Input.ParsingArgumentNotDefinedException;
 import InfrastructureManager.Modules.REST.Exception.Input.UnsupportedJSONTypeException;
+import InfrastructureManager.Modules.REST.RESTModuleObject;
 import InfrastructureManager.Modules.REST.RestServerRunner;
 import spark.Request;
 import spark.Response;
@@ -20,7 +21,7 @@ import static spark.Spark.post;
 /**
  * Class to represent data coming from POST requests, it can be configured to extract parameters from the request body json
  */
-public class POSTInput extends PlatformInput {
+public class POSTInput extends RESTModuleObject implements PlatformInput {
 
     private final Queue<String> toRead;
 

--- a/src/main/java/InfrastructureManager/Modules/REST/Input/UnknownJSONObject.java
+++ b/src/main/java/InfrastructureManager/Modules/REST/Input/UnknownJSONObject.java
@@ -2,7 +2,7 @@ package InfrastructureManager.Modules.REST.Input;
 
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
 import InfrastructureManager.Modules.REST.Exception.Input.UnsupportedJSONTypeException;
-import InfrastructureManager.PlatformObject;
+import InfrastructureManager.Modules.REST.RESTModuleObject;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 /**
  * Class to abstract a JSON object which has unknown parameters (Both type and value)
  */
-public class UnknownJSONObject extends PlatformObject {
+public class UnknownJSONObject extends RESTModuleObject {
 
     private final JsonNode tree;
     private final String body;

--- a/src/main/java/InfrastructureManager/Modules/REST/Output/GETOutput.java
+++ b/src/main/java/InfrastructureManager/Modules/REST/Output/GETOutput.java
@@ -3,6 +3,7 @@ package InfrastructureManager.Modules.REST.Output;
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
 import InfrastructureManager.ModuleManagement.PlatformOutput;
 import InfrastructureManager.Modules.REST.Exception.Output.RESTOutputException;
+import InfrastructureManager.Modules.REST.RESTModuleObject;
 import InfrastructureManager.Modules.REST.RestServerRunner;
 import spark.Request;
 import spark.Response;
@@ -14,7 +15,7 @@ import static spark.Spark.get;
  * Class to represent a MasterOutput that generates a REST resource to be consumed by GET requests
  * given the path in which the resource will be available and the json body of the desired response
  */
-public class GETOutput extends PlatformOutput {
+public class GETOutput extends RESTModuleObject implements PlatformOutput {
 
     private String toSend;
     protected final String URL;

--- a/src/main/java/InfrastructureManager/Modules/REST/Output/ParametrizedGETOutput.java
+++ b/src/main/java/InfrastructureManager/Modules/REST/Output/ParametrizedGETOutput.java
@@ -1,7 +1,6 @@
 package InfrastructureManager.Modules.REST.Output;
 
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
-import InfrastructureManager.ModuleManagement.PlatformModule;
 import InfrastructureManager.Modules.REST.Exception.Output.RESTOutputException;
 import spark.Request;
 import spark.Response;

--- a/src/main/java/InfrastructureManager/Modules/REST/RESTModuleObject.java
+++ b/src/main/java/InfrastructureManager/Modules/REST/RESTModuleObject.java
@@ -1,0 +1,14 @@
+package InfrastructureManager.Modules.REST;
+
+import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
+import InfrastructureManager.PlatformObject;
+
+public class RESTModuleObject extends PlatformObject {
+    public RESTModuleObject(ImmutablePlatformModule ownerModule) {
+        super(ownerModule);
+    }
+
+    public RESTModuleObject(ImmutablePlatformModule ownerModule, String name) {
+        super(ownerModule, name);
+    }
+}

--- a/src/main/java/InfrastructureManager/Modules/RemoteExecution/GlobalVarAccessREModule.java
+++ b/src/main/java/InfrastructureManager/Modules/RemoteExecution/GlobalVarAccessREModule.java
@@ -2,6 +2,6 @@ package InfrastructureManager.Modules.RemoteExecution;
 
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
 
-public interface GlobalVarAccessREModule extends ImmutablePlatformModule {
-    public LimitList getLimitList();
+interface GlobalVarAccessREModule extends ImmutablePlatformModule {
+    LimitList getLimitList();
 }

--- a/src/main/java/InfrastructureManager/Modules/RemoteExecution/GlobalVarAccessREModule.java
+++ b/src/main/java/InfrastructureManager/Modules/RemoteExecution/GlobalVarAccessREModule.java
@@ -1,0 +1,7 @@
+package InfrastructureManager.Modules.RemoteExecution;
+
+import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
+
+public interface GlobalVarAccessREModule extends ImmutablePlatformModule {
+    public LimitList getLimitList();
+}

--- a/src/main/java/InfrastructureManager/Modules/RemoteExecution/Input/NodeLimitInput.java
+++ b/src/main/java/InfrastructureManager/Modules/RemoteExecution/Input/NodeLimitInput.java
@@ -10,9 +10,9 @@ public class NodeLimitInput extends PlatformInput {
     private final LimitList sharedList;
     private String toSend;
 
-    public NodeLimitInput(ImmutablePlatformModule module, String name, LimitList list) {
+    public NodeLimitInput(ImmutablePlatformModule module, String name) {
         super(module,name);
-        this.sharedList = list;
+        this.sharedList = (LimitList) this.getOwnerModuleWithGlobalVar().getResource("limit_list");
         this.toSend = null;
     }
 

--- a/src/main/java/InfrastructureManager/Modules/RemoteExecution/Input/NodeLimitInput.java
+++ b/src/main/java/InfrastructureManager/Modules/RemoteExecution/Input/NodeLimitInput.java
@@ -4,15 +4,16 @@ import InfrastructureManager.ModuleManagement.Exception.Execution.ModuleExecutio
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
 import InfrastructureManager.ModuleManagement.PlatformInput;
 import InfrastructureManager.Modules.RemoteExecution.LimitList;
+import InfrastructureManager.Modules.RemoteExecution.RemoteExecutionModuleObject;
 
-public class NodeLimitInput extends PlatformInput {
+public class NodeLimitInput extends RemoteExecutionModuleObject implements PlatformInput {
 
     private final LimitList sharedList;
     private String toSend;
 
     public NodeLimitInput(ImmutablePlatformModule module, String name) {
         super(module,name);
-        this.sharedList = (LimitList) this.getOwnerModuleWithGlobalVar().getResource("limit_list");
+        this.sharedList = this.getLimitList();
         this.toSend = null;
     }
 

--- a/src/main/java/InfrastructureManager/Modules/RemoteExecution/LimitList.java
+++ b/src/main/java/InfrastructureManager/Modules/RemoteExecution/LimitList.java
@@ -1,8 +1,6 @@
 package InfrastructureManager.Modules.RemoteExecution;
 
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
-import InfrastructureManager.ModuleManagement.ModuleSharedResource;
-import InfrastructureManager.PlatformObject;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -10,7 +8,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Semaphore;
 
-public class LimitList extends PlatformObject implements ModuleSharedResource {
+public class LimitList extends RemoteExecutionModuleObject {
     private final ConcurrentMap<String, String> limitList;
     private final Semaphore block;
     private final ObjectMapper mapper;
@@ -22,7 +20,7 @@ public class LimitList extends PlatformObject implements ModuleSharedResource {
         this.mapper = new ObjectMapper();
     }
 
-    public ConcurrentMap<String, String> getLimitList() {
+    public ConcurrentMap<String, String> getList() {
         return limitList;
     }
 
@@ -35,13 +33,8 @@ public class LimitList extends PlatformObject implements ModuleSharedResource {
         }
     }
 
-    private void putValue(String key, String value) {
+    public void putValue(String key, String value) {
         this.limitList.put(key, value);
         this.block.release();
-    }
-
-    @Override
-    public void modify(String... data) {
-        this.putValue(data[0],data[1]);
     }
 }

--- a/src/main/java/InfrastructureManager/Modules/RemoteExecution/LimitList.java
+++ b/src/main/java/InfrastructureManager/Modules/RemoteExecution/LimitList.java
@@ -1,6 +1,7 @@
 package InfrastructureManager.Modules.RemoteExecution;
 
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
+import InfrastructureManager.ModuleManagement.ModuleSharedResource;
 import InfrastructureManager.PlatformObject;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -9,7 +10,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Semaphore;
 
-public class LimitList extends PlatformObject {
+public class LimitList extends PlatformObject implements ModuleSharedResource {
     private final ConcurrentMap<String, String> limitList;
     private final Semaphore block;
     private final ObjectMapper mapper;
@@ -34,8 +35,13 @@ public class LimitList extends PlatformObject {
         }
     }
 
-    public void putValue(String key, String value) {
+    private void putValue(String key, String value) {
         this.limitList.put(key, value);
         this.block.release();
+    }
+
+    @Override
+    public void modify(String... data) {
+        this.putValue(data[0],data[1]);
     }
 }

--- a/src/main/java/InfrastructureManager/Modules/RemoteExecution/Output/NodeLimitOutput.java
+++ b/src/main/java/InfrastructureManager/Modules/RemoteExecution/Output/NodeLimitOutput.java
@@ -8,11 +8,8 @@ import InfrastructureManager.Modules.RemoteExecution.LimitList;
 
 public class NodeLimitOutput extends PlatformOutput {
 
-    private final LimitList sharedList;
-
-    public NodeLimitOutput(ImmutablePlatformModule module, String name, LimitList list) {
+    public NodeLimitOutput(ImmutablePlatformModule module, String name) {
         super(module,name);
-        this.sharedList = list;
     }
 
     @Override
@@ -36,7 +33,9 @@ public class NodeLimitOutput extends PlatformOutput {
     private void addToLimitList(String tag, String limit, String period_ms) throws InvalidLimitParametersException {
         try {
             int quota_ms = (int) (Double.parseDouble(limit) * Integer.parseInt(period_ms));
-            this.sharedList.putValue(tag, quota_ms + "_" + period_ms);
+            this.getOwnerModuleWithGlobalVar()
+                    .getResource("limit_list")
+                    .modify(tag, quota_ms + "_" + period_ms);
         } catch (NumberFormatException | NullPointerException e) {
             throw new InvalidLimitParametersException("Parameters to set limits were invalid", e);
         }

--- a/src/main/java/InfrastructureManager/Modules/RemoteExecution/Output/NodeLimitOutput.java
+++ b/src/main/java/InfrastructureManager/Modules/RemoteExecution/Output/NodeLimitOutput.java
@@ -4,9 +4,9 @@ import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
 import InfrastructureManager.ModuleManagement.PlatformOutput;
 import InfrastructureManager.Modules.RemoteExecution.Exception.NodeLimit.InvalidLimitParametersException;
 import InfrastructureManager.Modules.RemoteExecution.Exception.NodeLimit.NodeLimitException;
-import InfrastructureManager.Modules.RemoteExecution.LimitList;
+import InfrastructureManager.Modules.RemoteExecution.RemoteExecutionModuleObject;
 
-public class NodeLimitOutput extends PlatformOutput {
+public class NodeLimitOutput extends RemoteExecutionModuleObject implements PlatformOutput {
 
     public NodeLimitOutput(ImmutablePlatformModule module, String name) {
         super(module,name);
@@ -33,9 +33,7 @@ public class NodeLimitOutput extends PlatformOutput {
     private void addToLimitList(String tag, String limit, String period_ms) throws InvalidLimitParametersException {
         try {
             int quota_ms = (int) (Double.parseDouble(limit) * Integer.parseInt(period_ms));
-            this.getOwnerModuleWithGlobalVar()
-                    .getResource("limit_list")
-                    .modify(tag, quota_ms + "_" + period_ms);
+            this.getLimitList().putValue(tag, quota_ms + "_" + period_ms);
         } catch (NumberFormatException | NullPointerException e) {
             throw new InvalidLimitParametersException("Parameters to set limits were invalid", e);
         }

--- a/src/main/java/InfrastructureManager/Modules/RemoteExecution/Output/SSHClient.java
+++ b/src/main/java/InfrastructureManager/Modules/RemoteExecution/Output/SSHClient.java
@@ -8,6 +8,7 @@ import InfrastructureManager.Modules.RemoteExecution.Exception.SSH.FileSending.F
 import InfrastructureManager.Modules.RemoteExecution.Exception.SSH.FileSending.InvalidFileException;
 import InfrastructureManager.Modules.RemoteExecution.Exception.SSH.FileSending.SCPProtocolException;
 import InfrastructureManager.Modules.RemoteExecution.Exception.SSH.SSHException;
+import InfrastructureManager.Modules.RemoteExecution.RemoteExecutionModuleObject;
 import com.jcraft.jsch.ChannelExec;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
@@ -16,7 +17,7 @@ import com.jcraft.jsch.Session;
 import java.io.*;
 import java.util.Arrays;
 
-public class SSHClient extends PlatformOutput {
+public class SSHClient extends RemoteExecutionModuleObject implements PlatformOutput {
 
     private final JSch jsch;
     private String username;

--- a/src/main/java/InfrastructureManager/Modules/RemoteExecution/RemoteExecutionModule.java
+++ b/src/main/java/InfrastructureManager/Modules/RemoteExecution/RemoteExecutionModule.java
@@ -6,12 +6,13 @@ import InfrastructureManager.Modules.RemoteExecution.Input.NodeLimitInput;
 import InfrastructureManager.Modules.RemoteExecution.Output.NodeLimitOutput;
 import InfrastructureManager.Modules.RemoteExecution.Output.SSHClient;
 
-public class RemoteExecutionModule extends PlatformModule {
+public class RemoteExecutionModule extends PlatformModule implements GlobalVarAccessREModule {
+
+    private final LimitList sharedList;
 
     public RemoteExecutionModule() {
         super();
-        LimitList sharedList = new LimitList(this);
-        this.addGlobalVariable("limit_list", sharedList);
+        this.sharedList = new LimitList(this);
     }
 
     @Override
@@ -21,5 +22,10 @@ public class RemoteExecutionModule extends PlatformModule {
         setInputs(new NodeLimitInput(this, name + ".limit.in"));
         setOutputs(new SSHClient(this,name + ".ssh.out"),
                 new NodeLimitOutput(this,name + ".limit.out"));
+    }
+
+    @Override
+    public LimitList getLimitList() {
+        return sharedList;
     }
 }

--- a/src/main/java/InfrastructureManager/Modules/RemoteExecution/RemoteExecutionModule.java
+++ b/src/main/java/InfrastructureManager/Modules/RemoteExecution/RemoteExecutionModule.java
@@ -10,15 +10,16 @@ public class RemoteExecutionModule extends PlatformModule {
 
     public RemoteExecutionModule() {
         super();
+        LimitList sharedList = new LimitList(this);
+        this.addGlobalVariable("limit_list", sharedList);
     }
 
     @Override
     public void configure(ModuleConfigData data) {
         String name = data.getName();
         setName(name);
-        LimitList sharedList = new LimitList(this);
-        setInputs(new NodeLimitInput(this, name + ".limit.in", sharedList));
+        setInputs(new NodeLimitInput(this, name + ".limit.in"));
         setOutputs(new SSHClient(this,name + ".ssh.out"),
-                new NodeLimitOutput(this,name + ".limit.out", sharedList));
+                new NodeLimitOutput(this,name + ".limit.out"));
     }
 }

--- a/src/main/java/InfrastructureManager/Modules/RemoteExecution/RemoteExecutionModuleObject.java
+++ b/src/main/java/InfrastructureManager/Modules/RemoteExecution/RemoteExecutionModuleObject.java
@@ -1,0 +1,19 @@
+package InfrastructureManager.Modules.RemoteExecution;
+
+import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
+import InfrastructureManager.PlatformObject;
+
+public class RemoteExecutionModuleObject extends PlatformObject {
+    public RemoteExecutionModuleObject(ImmutablePlatformModule ownerModule) {
+        super(ownerModule);
+    }
+
+    public RemoteExecutionModuleObject(ImmutablePlatformModule ownerModule, String name) {
+        super(ownerModule, name);
+    }
+
+    public LimitList getLimitList() {
+        GlobalVarAccessREModule castedModule = (GlobalVarAccessREModule) this.getOwnerModule();
+        return castedModule.getLimitList();
+    }
+}

--- a/src/main/java/InfrastructureManager/Modules/Scenario/Exception/ScenarioNotSetUpException.java
+++ b/src/main/java/InfrastructureManager/Modules/Scenario/Exception/ScenarioNotSetUpException.java
@@ -1,0 +1,7 @@
+package InfrastructureManager.Modules.Scenario.Exception;
+
+public class ScenarioNotSetUpException extends ScenarioModuleException {
+    public ScenarioNotSetUpException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/InfrastructureManager/Modules/Scenario/GlobalVarAccessScenarioModule.java
+++ b/src/main/java/InfrastructureManager/Modules/Scenario/GlobalVarAccessScenarioModule.java
@@ -1,0 +1,7 @@
+package InfrastructureManager.Modules.Scenario;
+
+import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
+
+public interface GlobalVarAccessScenarioModule extends ImmutablePlatformModule {
+    Scenario getScenario();
+}

--- a/src/main/java/InfrastructureManager/Modules/Scenario/GlobalVarAccessScenarioModule.java
+++ b/src/main/java/InfrastructureManager/Modules/Scenario/GlobalVarAccessScenarioModule.java
@@ -2,6 +2,6 @@ package InfrastructureManager.Modules.Scenario;
 
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
 
-public interface GlobalVarAccessScenarioModule extends ImmutablePlatformModule {
+interface GlobalVarAccessScenarioModule extends ImmutablePlatformModule {
     Scenario getScenario();
 }

--- a/src/main/java/InfrastructureManager/Modules/Scenario/Scenario.java
+++ b/src/main/java/InfrastructureManager/Modules/Scenario/Scenario.java
@@ -18,7 +18,7 @@ import java.util.concurrent.Semaphore;
  * Class representing an scenario, as an object with a name and a list of events
  */
 @JsonIgnoreProperties({"startBlock","startTime","currentIndex", "pausedTime",
-        "resumedTime","started","ownerModule", "name"})
+        "resumedTime","started"})
 public class Scenario extends ScenarioModuleObject implements PlatformInput {
 
     private final List<Event> eventList;

--- a/src/main/java/InfrastructureManager/Modules/Scenario/Scenario.java
+++ b/src/main/java/InfrastructureManager/Modules/Scenario/Scenario.java
@@ -1,8 +1,10 @@
 package InfrastructureManager.Modules.Scenario;
 
+import InfrastructureManager.ModuleManagement.Exception.Creation.IncorrectInputException;
 import InfrastructureManager.ModuleManagement.Exception.Execution.ModuleExecutionException;
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
 import InfrastructureManager.ModuleManagement.PlatformInput;
+import InfrastructureManager.ModuleManagement.Runner;
 import InfrastructureManager.Modules.Scenario.Exception.Input.InvalidTimeException;
 import InfrastructureManager.Modules.Scenario.Exception.Input.OwnerModuleNotSetUpException;
 import com.fasterxml.jackson.annotation.JacksonInject;
@@ -16,8 +18,8 @@ import java.util.concurrent.Semaphore;
  * Class representing an scenario, as an object with a name and a list of events
  */
 @JsonIgnoreProperties({"startBlock","startTime","currentIndex", "pausedTime",
-        "resumedTime","started", "name", "runner", "ownerModule"})
-public class Scenario extends PlatformInput {
+        "resumedTime","started","ownerModule", "name"})
+public class Scenario extends ScenarioModuleObject implements PlatformInput {
 
     private final List<Event> eventList;
     private final Semaphore startBlock;
@@ -122,12 +124,10 @@ public class Scenario extends PlatformInput {
 
     public void pause() {
         this.pausedTime += System.currentTimeMillis();
-        this.getRunner().pause();
     }
 
     public void resume() {
         this.resumedTime += System.currentTimeMillis();
-        this.getRunner().resume();
     }
 
     public void stop() {
@@ -135,7 +135,6 @@ public class Scenario extends PlatformInput {
         this.resumedTime = 0L;
         currentIndex = 0;
         this.started = false;
-        this.getRunner().exit();
         //System.out.println("FINISHED SCENARIO: " + this.getName());
     }
     /**

--- a/src/main/java/InfrastructureManager/Modules/Scenario/ScenarioDispatcher.java
+++ b/src/main/java/InfrastructureManager/Modules/Scenario/ScenarioDispatcher.java
@@ -5,6 +5,7 @@ import InfrastructureManager.ModuleManagement.PlatformOutput;
 import InfrastructureManager.Modules.Scenario.Exception.Input.InvalidTimeException;
 import InfrastructureManager.Modules.Scenario.Exception.Input.OwnerModuleNotSetUpException;
 import InfrastructureManager.Modules.Scenario.Exception.Output.ScenarioDispatcherException;
+import InfrastructureManager.Modules.Scenario.Exception.ScenarioNotSetUpException;
 
 /**
  * Scenario Handling class that is an Output of the master
@@ -13,15 +14,13 @@ import InfrastructureManager.Modules.Scenario.Exception.Output.ScenarioDispatche
  * - Run Scenarios
  * - Pause/Resume Scenarios
  */
-public class ScenarioDispatcher extends PlatformOutput {
+public class ScenarioDispatcher extends ScenarioModuleObject implements PlatformOutput {
 
-    private final Scenario scenario;
     private final ScenarioModule ownerScenarioModule;
     private static final int DEFAULT_DELAY = 1000; //1 second default delay
 
-    public ScenarioDispatcher(ImmutablePlatformModule module, String name, Scenario scenario) {
+    public ScenarioDispatcher(ImmutablePlatformModule module, String name) {
         super(module,name);
-        this.scenario = scenario;
         this.ownerScenarioModule = (ScenarioModule) module;
     }
 
@@ -77,6 +76,8 @@ public class ScenarioDispatcher extends PlatformOutput {
             } catch (IndexOutOfBoundsException e){
                 throw new ScenarioDispatcherException("Arguments missing for command " + response
                         + " to ScenarioDispatcher");
+            } catch (ScenarioNotSetUpException e) {
+                throw  new ScenarioDispatcherException("Scenario could not be accessed in the module");
             }
         }
     }
@@ -84,21 +85,21 @@ public class ScenarioDispatcher extends PlatformOutput {
     /**
      * Method for stopping the current scenario
      */
-    private void stopScenario() {
+    private void stopScenario() throws ScenarioNotSetUpException {
         this.ownerScenarioModule.stopScenario();
     }
 
     /**
      * Method for pausing the scenario
      */
-    private void pauseScenario() {
+    private void pauseScenario() throws ScenarioNotSetUpException {
         this.ownerScenarioModule.pauseScenario();
     }
 
     /**
      * Method to resume the scenario if paused
      */
-    private void resumeScenario() {
+    private void resumeScenario() throws ScenarioNotSetUpException {
         this.ownerScenarioModule.resumeScenario();
     }
 
@@ -106,16 +107,6 @@ public class ScenarioDispatcher extends PlatformOutput {
      * Method to run the scenario
      */
     private void runScenario(long startTime) throws InvalidTimeException, OwnerModuleNotSetUpException {
-        this.getLogger().debug("starting scenario " + this.scenario.getName());
         this.ownerScenarioModule.startScenario(startTime);
-    }
-
-
-    /**
-     * Get the scenario assigned to this dispatcher
-     * @return Scenario to which all action will be performed
-     */
-    public Scenario getScenario() { //FOR TESTS
-        return scenario;
     }
 }

--- a/src/main/java/InfrastructureManager/Modules/Scenario/ScenarioEditor.java
+++ b/src/main/java/InfrastructureManager/Modules/Scenario/ScenarioEditor.java
@@ -19,14 +19,14 @@ import java.io.IOException;
  * - Save Scenarios to JSON Files
  * - Load Scenarios from JSON Files
  */
-public class ScenarioEditor extends PlatformOutput {
+public class ScenarioEditor extends ScenarioModuleObject implements PlatformOutput {
 
     private final Scenario scenario;
     private final ObjectMapper mapper;
 
-    public ScenarioEditor(ImmutablePlatformModule module, String name, Scenario scenario) {
+    public ScenarioEditor(ImmutablePlatformModule module, String name) {
         super(module,name);
-        this.scenario = scenario;
+        this.scenario = this.getScenario();
         //When saving to a file, make so the JSON string is indented and "pretty"
         this.mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
     }
@@ -92,13 +92,5 @@ public class ScenarioEditor extends PlatformOutput {
         } catch (IOException e) {
             throw new ScenarioIOException("Scenario " + scenario.getName() + " could not be saved", e);
         }
-    }
-
-    /**
-     * Get the scenario being edited
-     * @return Scenario being edited in the editor
-     */
-    public Scenario getScenario() { //FOR TESTS
-        return scenario;
     }
 }

--- a/src/main/java/InfrastructureManager/Modules/Scenario/ScenarioModule.java
+++ b/src/main/java/InfrastructureManager/Modules/Scenario/ScenarioModule.java
@@ -1,10 +1,13 @@
 package InfrastructureManager.Modules.Scenario;
 
+import InfrastructureManager.ModuleManagement.Exception.Creation.IncorrectInputException;
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
 import InfrastructureManager.ModuleManagement.PlatformModule;
 import InfrastructureManager.ModuleManagement.RawData.ModuleConfigData;
+import InfrastructureManager.ModuleManagement.Runner;
 import InfrastructureManager.Modules.Scenario.Exception.Input.InvalidTimeException;
 import InfrastructureManager.Modules.Scenario.Exception.Input.OwnerModuleNotSetUpException;
+import InfrastructureManager.Modules.Scenario.Exception.ScenarioNotSetUpException;
 import InfrastructureManager.Modules.Scenario.RawData.ScenarioModuleConfigData;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -12,7 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
 
-public class ScenarioModule extends PlatformModule {
+public class ScenarioModule extends PlatformModule implements GlobalVarAccessScenarioModule {
 
     private Scenario scenario;
 
@@ -28,8 +31,8 @@ public class ScenarioModule extends PlatformModule {
             Scenario scenario = scenarioFromFile(castedData.getPath());
             setInputs(scenario);
             this.scenario = (Scenario) this.getInputs().get(0);
-            setOutputs(new ScenarioEditor(this,this.getName() + ".editor", scenario),
-                    new ScenarioDispatcher(this,this.getName() + ".dispatcher", scenario));
+            setOutputs(new ScenarioEditor(this,this.getName() + ".editor"),
+                    new ScenarioDispatcher(this,this.getName() + ".dispatcher"));
 
         } catch (IOException e) {
             e.printStackTrace();
@@ -44,16 +47,19 @@ public class ScenarioModule extends PlatformModule {
         scenario.start();
     }
 
-    public void stopScenario() {
+    public void stopScenario() throws ScenarioNotSetUpException {
         scenario.stop();
+        getScenarioRunner().exit();
     }
 
-    public void pauseScenario() {
+    public void pauseScenario() throws ScenarioNotSetUpException {
         scenario.pause();
+        getScenarioRunner().pause();
     }
 
-    public void resumeScenario() {
+    public void resumeScenario() throws ScenarioNotSetUpException {
         scenario.resume();
+        getScenarioRunner().resume();
     }
 
     private Scenario scenarioFromFile(String path) throws IOException {
@@ -62,5 +68,18 @@ public class ScenarioModule extends PlatformModule {
                 .addValue(ImmutablePlatformModule.class, this);
         mapper.setInjectableValues(inject);
         return mapper.readValue(new File(path),Scenario.class);
+    }
+
+    @Override
+    public Scenario getScenario() {
+        return scenario;
+    }
+
+    private Runner getScenarioRunner() throws ScenarioNotSetUpException {
+        try {
+            return this.getRunnerFromInput(this.getName() + ".scenario");
+        } catch (IncorrectInputException e) {
+            throw new ScenarioNotSetUpException("Scenario has not been set up in module " + this.getName());
+        }
     }
 }

--- a/src/main/java/InfrastructureManager/Modules/Scenario/ScenarioModuleObject.java
+++ b/src/main/java/InfrastructureManager/Modules/Scenario/ScenarioModuleObject.java
@@ -1,0 +1,21 @@
+package InfrastructureManager.Modules.Scenario;
+
+import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
+import InfrastructureManager.PlatformObject;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public class ScenarioModuleObject extends PlatformObject {
+    public ScenarioModuleObject(ImmutablePlatformModule ownerModule) {
+        super(ownerModule);
+    }
+
+    public ScenarioModuleObject(ImmutablePlatformModule ownerModule, String name) {
+        super(ownerModule, name);
+    }
+
+    @JsonIgnore
+    public Scenario getScenario() {
+        GlobalVarAccessScenarioModule casted = (GlobalVarAccessScenarioModule) this.getOwnerModule();
+        return casted.getScenario();
+    }
+}

--- a/src/main/java/InfrastructureManager/Modules/Utility/FileOutput.java
+++ b/src/main/java/InfrastructureManager/Modules/Utility/FileOutput.java
@@ -12,7 +12,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Arrays;
 
-public class FileOutput extends PlatformOutput {
+public class FileOutput extends UtilityModuleObject implements PlatformOutput {
 
     private Charset encoding;
 

--- a/src/main/java/InfrastructureManager/Modules/Utility/ModuleController.java
+++ b/src/main/java/InfrastructureManager/Modules/Utility/ModuleController.java
@@ -11,7 +11,7 @@ import InfrastructureManager.Modules.Utility.Exception.ModuleController.ModuleCo
 /**
  * Class implementing MasterOutput, for utilities within the master
  */
-public class ModuleController extends PlatformOutput {
+public class ModuleController extends UtilityModuleObject implements PlatformOutput {
 
     public ModuleController(ImmutablePlatformModule module, String name) {
         super(module,name);

--- a/src/main/java/InfrastructureManager/Modules/Utility/UtilityModuleObject.java
+++ b/src/main/java/InfrastructureManager/Modules/Utility/UtilityModuleObject.java
@@ -1,0 +1,14 @@
+package InfrastructureManager.Modules.Utility;
+
+import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
+import InfrastructureManager.PlatformObject;
+
+public class UtilityModuleObject extends PlatformObject {
+    public UtilityModuleObject(ImmutablePlatformModule ownerModule) {
+        super(ownerModule);
+    }
+
+    public UtilityModuleObject(ImmutablePlatformModule ownerModule, String name) {
+        super(ownerModule, name);
+    }
+}

--- a/src/main/java/InfrastructureManager/PlatformObject.java
+++ b/src/main/java/InfrastructureManager/PlatformObject.java
@@ -1,8 +1,8 @@
 package InfrastructureManager;
 
-import InfrastructureManager.ModuleManagement.GlobalVarAccessPlatformModule;
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
 import InfrastructureManager.ModuleManagement.ModuleDebugInput;
+import InfrastructureManager.ModuleManagement.PlatformModule;
 
 /**
  * Base class for objects of the platform. All objects that are used in / are part of a module,
@@ -12,15 +12,27 @@ import InfrastructureManager.ModuleManagement.ModuleDebugInput;
 public abstract class PlatformObject {
 
     private final ImmutablePlatformModule ownerModule;
-
+    private final String name;
     /**
      * Constructor of the class.
      * @param ownerModule The module which to which this object belongs
      */
     public PlatformObject(ImmutablePlatformModule ownerModule) {
-        this.ownerModule = ownerModule;
+        this(ownerModule,"");
     }
 
+    public PlatformObject(ImmutablePlatformModule ownerModule, String name) {
+        this.ownerModule = ownerModule;
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public PlatformModule.ModuleState getOwnerModuleState() {
+        return this.ownerModule.getState();
+    }
 
     /**
      * Access the owner module of this object
@@ -30,10 +42,6 @@ public abstract class PlatformObject {
         return ownerModule;
     }
 
-
-    protected GlobalVarAccessPlatformModule getOwnerModuleWithGlobalVar() {
-        return (GlobalVarAccessPlatformModule) ownerModule;
-    }
 
     /**
      * Access the {@link ModuleDebugInput} inside the owner module of this object. This can then be

--- a/src/main/java/InfrastructureManager/PlatformObject.java
+++ b/src/main/java/InfrastructureManager/PlatformObject.java
@@ -3,12 +3,14 @@ package InfrastructureManager;
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
 import InfrastructureManager.ModuleManagement.ModuleDebugInput;
 import InfrastructureManager.ModuleManagement.PlatformModule;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 /**
  * Base class for objects of the platform. All objects that are used in / are part of a module,
  * must extend this class, in order to have access to its module's {@link ModuleDebugInput} and
  * be able to log information.
  */
+@JsonIgnoreProperties({"ownerModule", "name","ownerModuleState", "logger"})
 public abstract class PlatformObject {
 
     private final ImmutablePlatformModule ownerModule;

--- a/src/main/java/InfrastructureManager/PlatformObject.java
+++ b/src/main/java/InfrastructureManager/PlatformObject.java
@@ -1,5 +1,6 @@
 package InfrastructureManager;
 
+import InfrastructureManager.ModuleManagement.GlobalVarAccessPlatformModule;
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
 import InfrastructureManager.ModuleManagement.ModuleDebugInput;
 
@@ -27,6 +28,11 @@ public abstract class PlatformObject {
      */
     protected ImmutablePlatformModule getOwnerModule() {
         return ownerModule;
+    }
+
+
+    protected GlobalVarAccessPlatformModule getOwnerModuleWithGlobalVar() {
+        return (GlobalVarAccessPlatformModule) ownerModule;
     }
 
     /**

--- a/src/test/java/InfrastructureManager/Modules/MatchMaking/InputUnitTests/MatchMakingInputTests.java
+++ b/src/test/java/InfrastructureManager/Modules/MatchMaking/InputUnitTests/MatchMakingInputTests.java
@@ -14,12 +14,11 @@ import org.junit.Test;
 public class MatchMakingInputTests {
 
     private final MatchMakingModule module = new MatchMakingModule(); //Generic Module
-    private final MatchesList matchesList = new MatchesList(module);
-    private final MatchMakerInput input = new MatchMakerInput(module, "mm.in", matchesList);
+    private final MatchMakerInput input = new MatchMakerInput(module, "mm.in");
 
     @Test
     public void correctInputReadWithRandomMatchMakerOutputTest() throws InterruptedException, ModuleExecutionException {
-        MatchMakerOutput output = new MatchMakerOutput(module,"mm.out", new RandomMatchMaking(module),matchesList);
+        MatchMakerOutput output = new MatchMakerOutput(module,"mm.out", new RandomMatchMaking(module));
         String node = "{\"id\":\"node1\",\"ipAddress\":\"192.168.0.1\",\"connected\":true}";
         String client = "{\"id\":\"client1\"}";
         registerNodeAndClient(output,node,client);
@@ -31,7 +30,7 @@ public class MatchMakingInputTests {
 
     @Test
     public void correctInputReadWithNaiveMatchMakerOutputTest() throws InterruptedException, ModuleExecutionException {
-        MatchMakerOutput output = new MatchMakerOutput(module,"mm.out", new NaiveMatchMaking(module),matchesList);
+        MatchMakerOutput output = new MatchMakerOutput(module,"mm.out", new NaiveMatchMaking(module));
         String node = "{\"id\":\"node1\",\"ipAddress\":\"68.131.232.215:30968\",\"connected\":true,\"resource\":100,\"totalResource\":200,\"network\":100,\"totalNetwork\":200,\"location\":55}";
         String client = "{\"id\":\"client1\",\"reqNetwork\":5,\"reqResource\":10,\"location\":54}";
         registerNodeAndClient(output,node,client);
@@ -43,7 +42,7 @@ public class MatchMakingInputTests {
 
     @Test
     public void correctInputReadWithScoreMatchMakerOutputTest() throws InterruptedException, ModuleExecutionException {
-        MatchMakerOutput output = new MatchMakerOutput(module,"mm.out", new ScoreBasedMatchMaking(module),matchesList);
+        MatchMakerOutput output = new MatchMakerOutput(module,"mm.out", new ScoreBasedMatchMaking(module));
         String node = "{\"id\":\"node1\",\"ipAddress\":\"68.131.232.215:30968\",\"connected\":true,\"resource\":100,\"totalResource\":200,\"network\":100,\"totalNetwork\":200,\"location\":55}";
         String client = "{\"id\":\"client1\",\"reqNetwork\":5,\"reqResource\":10,\"location\":54}";
         registerNodeAndClient(output,node,client);

--- a/src/test/java/InfrastructureManager/Modules/MatchMaking/OutputUnitTests/MatchMakingGeneralOutputTests.java
+++ b/src/test/java/InfrastructureManager/Modules/MatchMaking/OutputUnitTests/MatchMakingGeneralOutputTests.java
@@ -4,7 +4,6 @@ import InfrastructureManager.ModuleManagement.Exception.Execution.ModuleExecutio
 import InfrastructureManager.Modules.CommonTestingMethods;
 import InfrastructureManager.Modules.MatchMaking.Exception.MatchMakingModuleException;
 import InfrastructureManager.Modules.MatchMaking.MatchMakingModule;
-import InfrastructureManager.Modules.MatchMaking.MatchesList;
 import InfrastructureManager.Modules.MatchMaking.Output.MatchMakerOutput;
 import InfrastructureManager.Modules.MatchMaking.Random.RandomMatchMaking;
 import org.junit.Assert;
@@ -13,8 +12,7 @@ import org.junit.Test;
 public class MatchMakingGeneralOutputTests {
 
     private final MatchMakingModule module = new MatchMakingModule();
-    private final MatchesList matchesList = new MatchesList(module);
-    private final MatchMakerOutput matchMaker = new MatchMakerOutput(module,"mm", new RandomMatchMaking(module), matchesList);
+    private final MatchMakerOutput matchMaker = new MatchMakerOutput(module,"mm", new RandomMatchMaking(module));
 
     @Test
     public void registerNodeTest() throws ModuleExecutionException {

--- a/src/test/java/InfrastructureManager/Modules/MatchMaking/OutputUnitTests/MatchMakingNaiveTest.java
+++ b/src/test/java/InfrastructureManager/Modules/MatchMaking/OutputUnitTests/MatchMakingNaiveTest.java
@@ -3,7 +3,6 @@ package InfrastructureManager.Modules.MatchMaking.OutputUnitTests;
 import InfrastructureManager.ModuleManagement.Exception.Execution.ModuleExecutionException;
 import InfrastructureManager.Modules.MatchMaking.Client.EdgeClient;
 import InfrastructureManager.Modules.MatchMaking.MatchMakingModule;
-import InfrastructureManager.Modules.MatchMaking.MatchesList;
 import InfrastructureManager.Modules.MatchMaking.Naive.NaiveMatchMaking;
 import InfrastructureManager.Modules.MatchMaking.Node.EdgeNode;
 import InfrastructureManager.Modules.MatchMaking.Output.MatchMakerOutput;
@@ -17,8 +16,7 @@ import java.util.regex.Pattern;
 public class MatchMakingNaiveTest {
 
     private final MatchMakingModule module = new MatchMakingModule();
-    private final MatchesList matchesList = new MatchesList(module);
-    private final MatchMakerOutput matchMaker = new MatchMakerOutput(module,"mm", new NaiveMatchMaking(module), matchesList);
+    private final MatchMakerOutput matchMaker = new MatchMakerOutput(module,"mm", new NaiveMatchMaking(module));
 
     @Before
     public void register3NodesAnd2Clients() throws ModuleExecutionException {
@@ -59,11 +57,11 @@ public class MatchMakingNaiveTest {
 
         matchMaker.execute("matchMaker assign_client client1");
         //client1 should be mapped to node1 because is closer
-        String thisShouldBeNode1 = getNodeIDFromJSON(matchesList.getMapping().get("client1"));
+        String thisShouldBeNode1 = getNodeIDFromJSON(module.getSharedList().getMapping().get("client1"));
         Assert.assertEquals("node1", thisShouldBeNode1);
 
         matchMaker.execute("matchMaker assign_client client2");
-        String thisShouldBeNode2 = getNodeIDFromJSON(matchesList.getMapping().get("client2"));
+        String thisShouldBeNode2 = getNodeIDFromJSON(module.getSharedList().getMapping().get("client2"));
         //Should be node 2 because node2 is closer to client 2 than others
         Assert.assertEquals("node2", thisShouldBeNode2);
     }
@@ -76,7 +74,7 @@ public class MatchMakingNaiveTest {
         //Re assign client 1
         matchMaker.execute("matchMaker assign_client client1");
         //Should still be node 1, the distance hasn't changed yet
-        String thisShouldBeNode1 = getNodeIDFromJSON(matchesList.getMapping().get("client1"));
+        String thisShouldBeNode1 = getNodeIDFromJSON(module.getSharedList().getMapping().get("client1"));
         Assert.assertEquals("node1", thisShouldBeNode1);
     }
 
@@ -88,7 +86,7 @@ public class MatchMakingNaiveTest {
         //update node2 so it will be damn far away from client 2, making client 2 must connect to node 1
         matchMaker.execute("matchMaker register_node {\"id\":\"node2\",\"ipAddress\":\"92.183.84.109:42589\",\"connected\":true,\"resource\":100,\"totalResource\":200,\"network\":100,\"totalNetwork\":200,\"location\":133}");
         matchMaker.execute("matchMaker assign_client client2");
-        String thisShouldBeNode1ForThis = getNodeIDFromJSON(matchesList.getMapping().get("client2"));
+        String thisShouldBeNode1ForThis = getNodeIDFromJSON(module.getSharedList().getMapping().get("client2"));
         //Should be node 1 because node1 is closer to client 2 than others
         Assert.assertEquals("node1", thisShouldBeNode1ForThis);
     }

--- a/src/test/java/InfrastructureManager/Modules/MatchMaking/OutputUnitTests/MatchMakingRandomTests.java
+++ b/src/test/java/InfrastructureManager/Modules/MatchMaking/OutputUnitTests/MatchMakingRandomTests.java
@@ -2,7 +2,6 @@ package InfrastructureManager.Modules.MatchMaking.OutputUnitTests;
 
 import InfrastructureManager.ModuleManagement.Exception.Execution.ModuleExecutionException;
 import InfrastructureManager.Modules.MatchMaking.MatchMakingModule;
-import InfrastructureManager.Modules.MatchMaking.MatchesList;
 import InfrastructureManager.Modules.MatchMaking.Output.MatchMakerOutput;
 import InfrastructureManager.Modules.MatchMaking.Random.RandomMatchMaking;
 import org.junit.Assert;
@@ -11,8 +10,7 @@ import org.junit.Test;
 public class MatchMakingRandomTests {
 
     private final MatchMakingModule module = new MatchMakingModule();
-    private final MatchesList matchesList = new MatchesList(module);
-    private final MatchMakerOutput matchMaker = new MatchMakerOutput(module,"mm", new RandomMatchMaking(module), matchesList);
+    private final MatchMakerOutput matchMaker = new MatchMakerOutput(module,"mm", new RandomMatchMaking(module));
 
     @Test
     public void assignNodeToClientCompleteTest() throws InterruptedException, ModuleExecutionException {
@@ -20,7 +18,7 @@ public class MatchMakingRandomTests {
         matchMaker.execute("matchMaker register_node {\"id\":\"node1\",\"ipAddress\":\"192.168.0.1\",\"connected\":true}");
         matchMaker.execute("matchMaker register_client {\"id\":\"client1\"}");
         matchMaker.execute("matchMaker assign_client client1");
-        String result = matchesList.getLastAdded();
+        String result = module.getSharedList().getLastAdded();
         String expected = "client1 {\"id\":\"node1\",\"ipAddress\":\"192.168.0.1\",\"connected\":true,\"resource\":0,\"network\":0,\"location\":0,\"totalResource\":0,\"totalNetwork\":0}";
         Assert.assertEquals(expected,result);
     }

--- a/src/test/java/InfrastructureManager/Modules/MatchMaking/OutputUnitTests/MatchMakingScoreTest.java
+++ b/src/test/java/InfrastructureManager/Modules/MatchMaking/OutputUnitTests/MatchMakingScoreTest.java
@@ -4,7 +4,6 @@ import InfrastructureManager.ModuleManagement.Exception.Execution.ModuleExecutio
 import InfrastructureManager.Modules.MatchMaking.Client.EdgeClient;
 import InfrastructureManager.Modules.MatchMaking.Client.EdgeClientHistory;
 import InfrastructureManager.Modules.MatchMaking.MatchMakingModule;
-import InfrastructureManager.Modules.MatchMaking.MatchesList;
 import InfrastructureManager.Modules.MatchMaking.Node.EdgeNode;
 import InfrastructureManager.Modules.MatchMaking.Output.MatchMakerOutput;
 import InfrastructureManager.Modules.MatchMaking.ScoreBased.ScoreBasedMatchMaking;
@@ -20,8 +19,7 @@ import java.util.regex.Pattern;
 public class MatchMakingScoreTest {
 
     private final MatchMakingModule module = new MatchMakingModule();
-    private final MatchesList matchesList = new MatchesList(module);
-    private final MatchMakerOutput matchMaker = new MatchMakerOutput(module,"mm", new ScoreBasedMatchMaking(module), matchesList);
+    private final MatchMakerOutput matchMaker = new MatchMakerOutput(module,"mm", new ScoreBasedMatchMaking(module));
 
     @Before
     public void register3NodesAnd2Clients() throws ModuleExecutionException {
@@ -63,7 +61,7 @@ public class MatchMakingScoreTest {
 
         matchMaker.execute("matchMaker assign_client client1");
         //client1 should be mapped to node1
-        String thisShouldBeNode1 = getNodeIDFromJSON(matchesList.getMapping().get("client1"));
+        String thisShouldBeNode1 = getNodeIDFromJSON(module.getSharedList().getMapping().get("client1"));
         Assert.assertEquals("node1", thisShouldBeNode1);
     }
 
@@ -89,7 +87,7 @@ public class MatchMakingScoreTest {
         Assert.assertEquals(8,thisShouldBe8);
 
         //Client 1 should connect to node 2 now cuz node 2 have better score
-        String thisShouldBeNode2 = getNodeIDFromJSON(matchesList.getMapping().get("client1"));
+        String thisShouldBeNode2 = getNodeIDFromJSON(module.getSharedList().getMapping().get("client1"));
         Assert.assertEquals("node2",thisShouldBeNode2);
     }
 

--- a/src/test/java/InfrastructureManager/Modules/RemoteExecution/InputUnitTests/NodeLimitInputTests.java
+++ b/src/test/java/InfrastructureManager/Modules/RemoteExecution/InputUnitTests/NodeLimitInputTests.java
@@ -2,7 +2,6 @@ package InfrastructureManager.Modules.RemoteExecution.InputUnitTests;
 
 import InfrastructureManager.ModuleManagement.Exception.Execution.ModuleExecutionException;
 import InfrastructureManager.Modules.RemoteExecution.Input.NodeLimitInput;
-import InfrastructureManager.Modules.RemoteExecution.LimitList;
 import InfrastructureManager.Modules.RemoteExecution.Output.NodeLimitOutput;
 import InfrastructureManager.Modules.RemoteExecution.RemoteExecutionModule;
 import org.junit.Assert;

--- a/src/test/java/InfrastructureManager/Modules/RemoteExecution/InputUnitTests/NodeLimitInputTests.java
+++ b/src/test/java/InfrastructureManager/Modules/RemoteExecution/InputUnitTests/NodeLimitInputTests.java
@@ -11,9 +11,8 @@ import org.junit.Test;
 public class NodeLimitInputTests {
 
     RemoteExecutionModule module = new RemoteExecutionModule();
-    private final LimitList list = new LimitList(module);
-    private final NodeLimitOutput output = new NodeLimitOutput(module,"limit.out", list);
-    private final NodeLimitInput input = new NodeLimitInput(module, "limit.in", list);
+    private final NodeLimitOutput output = new NodeLimitOutput(module,"limit.out");
+    private final NodeLimitInput input = new NodeLimitInput(module, "limit.in");
 
     @Test
     public void limitBodyIsCorrectWithDefaultPeriod() throws ModuleExecutionException, InterruptedException {

--- a/src/test/java/InfrastructureManager/Modules/RemoteExecution/OutputUnitTests/NodeLimitOutputTests.java
+++ b/src/test/java/InfrastructureManager/Modules/RemoteExecution/OutputUnitTests/NodeLimitOutputTests.java
@@ -13,8 +13,8 @@ import org.junit.Test;
 public class NodeLimitOutputTests {
 
     RemoteExecutionModule module = new RemoteExecutionModule();
-    private final LimitList list = new LimitList(module);
-    private final NodeLimitOutput output = new NodeLimitOutput(module,"limit.out", list);
+    private final LimitList list = (LimitList) module.getResource("limit_list");
+    private final NodeLimitOutput output = new NodeLimitOutput(module,"limit.out");
 
     private void assertExceptionInOutput(Class<? extends Exception> exceptionClass, String expectedMessage, String command) {
         CommonTestingMethods.assertException(exceptionClass, expectedMessage, () -> output.execute(command));

--- a/src/test/java/InfrastructureManager/Modules/RemoteExecution/OutputUnitTests/NodeLimitOutputTests.java
+++ b/src/test/java/InfrastructureManager/Modules/RemoteExecution/OutputUnitTests/NodeLimitOutputTests.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 public class NodeLimitOutputTests {
 
     RemoteExecutionModule module = new RemoteExecutionModule();
-    private final LimitList list = (LimitList) module.getResource("limit_list");
+    private final LimitList list = module.getLimitList();
     private final NodeLimitOutput output = new NodeLimitOutput(module,"limit.out");
 
     private void assertExceptionInOutput(Class<? extends Exception> exceptionClass, String expectedMessage, String command) {
@@ -24,14 +24,14 @@ public class NodeLimitOutputTests {
     public void limitsAreAddedWithDefaultPeriod() throws ModuleExecutionException {
         output.execute("limit cores node1 0.5");
         String expectedLimitForNode1 = "50000_100000";
-        Assert.assertEquals(expectedLimitForNode1, list.getLimitList().get("node1"));
+        Assert.assertEquals(expectedLimitForNode1, list.getList().get("node1"));
     }
 
     @Test
     public void limitsAreAddedWithCustomPeriod() throws ModuleExecutionException {
         output.execute("limit cores node1 0.5 1000");
         String expectedLimitForNode1 = "500_1000";
-        Assert.assertEquals(expectedLimitForNode1, list.getLimitList().get("node1"));
+        Assert.assertEquals(expectedLimitForNode1, list.getList().get("node1"));
     }
 
     @Test

--- a/src/test/java/InfrastructureManager/Modules/Scenario/InputUnitTests/ScenarioInputTests.java
+++ b/src/test/java/InfrastructureManager/Modules/Scenario/InputUnitTests/ScenarioInputTests.java
@@ -1,7 +1,6 @@
 package InfrastructureManager.Modules.Scenario.InputUnitTests;
 
 import InfrastructureManager.ModuleManagement.ImmutablePlatformModule;
-import InfrastructureManager.ModuleManagement.PlatformModule;
 import InfrastructureManager.Modules.CommonTestingMethods;
 import InfrastructureManager.Modules.Scenario.Event;
 import InfrastructureManager.Modules.Scenario.Exception.Input.InvalidTimeException;

--- a/src/test/java/InfrastructureManager/Modules/Scenario/OutputUnitTests/ScenarioDispatcherTests.java
+++ b/src/test/java/InfrastructureManager/Modules/Scenario/OutputUnitTests/ScenarioDispatcherTests.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 public class ScenarioDispatcherTests {
 
     private ScenarioDispatcher dispatcher;
-    private static Scenario scenario;
     static final long WAITING_TIME = 12000; //If events are delayed this has to be modified
     private final ByteArrayOutputStream outContent;
     private static ScenarioModule module = new ScenarioModule();
@@ -45,16 +44,11 @@ public class ScenarioDispatcherTests {
         ModuleManager manager = Master.getInstance().getManager();
         manager.startAllModules();
         module = findModule(manager);
-        InjectableValues inject = new InjectableValues.Std().addValue(ImmutablePlatformModule.class, module);
-        String scenarioPath = "src/test/resources/Modules/Scenario/dummyScenario.json";
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setInjectableValues(inject);
-        scenario = mapper.readValue(new File(scenarioPath), Scenario.class);
     }
 
     @Before
     public void init() {
-        dispatcher = new ScenarioDispatcher(module,"dummy.dispatcher", scenario);
+        dispatcher = new ScenarioDispatcher(module,"dummy.dispatcher");
     }
 
     private static ScenarioModule findModule(ModuleManager manager) throws ModuleNotFoundException, ModuleManagerException {


### PR DESCRIPTION
Based on the discussion, this is the first attempt to refactor the resource sharing in modules.

So far:
- `ImmutablePlatformModule` is now an interface
- Added a `GlobalVarAccessPlatformModule` interface to represent limited access (only access to the global variables)
- In the super class `PlatformObject`, added a method to get the owner module with global variable access
- Added a `ModuleShareResource` interface, which the different shared objects in the modules will implement
- In the modules, there is now a `globalVariables` map that relates a name to a `ModuleSharedResource`
- Modified `RemoteExecutionModule` to work with the new functionalities and tests it still works

The biggest issue is that is order to have a `ModuleShareResource` interface (or even to have a `GlobalVarAccessPlatformModule` interface) the shared resources have to be abstracted somehow. So in this first iteration, a shared resource is characterized by having a method to modify it (which recieves data as Strings). I realize that is very general (and may be wrong) but the alternative would be to use generics, and either making everything generic (`PlatformModule` generic) or just making the `GlobalVarAccessPlatformModule` interface generic but then, each module should implement it separately (the abstract `PlatformModule` could not implement it, not knowing the type of the shared resource).

Have a look at the code, and let me know what you think @alyhasansakr 