### PR TITLE
Fixed javadoc errors

### DIFF
--- a/src/main/java/InfrastructureManager/Configuration/CommandSet.java
+++ b/src/main/java/InfrastructureManager/Configuration/CommandSet.java
@@ -38,7 +38,7 @@ public class CommandSet {
 
     /**
      * Set the command set to a given map
-     * @param config Map<String,String> element containing the commands in the form of ({command} : {response})
+     * @param config Map element containing the commands where for each entry, the key is the command and the value is the response.
      */
     public void set(Map<String, String> config) {
         this.commands = config;
@@ -47,7 +47,7 @@ public class CommandSet {
 
     /**
      * Return the commands in form of a map
-     * @return Map<String,String> element containing the commands in the form of ({command} : {response})
+     * @return Map element containing the commands where for each entry, the key is the command and the value is the response.
      */
     public Map<String, String> get() {
         return this.commands;

--- a/src/main/java/InfrastructureManager/Modules/Console/ConsoleOutput.java
+++ b/src/main/java/InfrastructureManager/Modules/Console/ConsoleOutput.java
@@ -24,7 +24,7 @@ public class ConsoleOutput extends ConsoleModuleObject implements PlatformOutput
      * Method for outputting to the console
      * @param response Message to be outputted to the console.
      *                The command has to be preceded by "console".
-     *                 For example: "console hello" -> prints hello.
+     *                 For example: "console hello" prints hello.
      *                 If more than one argument is passed, they should be separated by spaces and will be printed in the same way
      * @throws ConsoleOutputException if the command is missing arguments (no argument passed after "console")
      */

--- a/src/main/java/InfrastructureManager/Modules/MatchMaking/ScoreBased/ScoreBasedMatchMaking.java
+++ b/src/main/java/InfrastructureManager/Modules/MatchMaking/ScoreBased/ScoreBasedMatchMaking.java
@@ -16,12 +16,15 @@ import java.util.*;
 
 /**
  * Score-based match making algorithm.
- * Score = Wd_D + Wc_C + Wn_N + Wh_H --- D = ping, C = res, N = network, H = history
- * Weight: 1 - 10 - 10 - 10
  *
  * @author Zero
  */
 public class ScoreBasedMatchMaking extends MatchMakingModuleObject implements MatchMakingAlgorithm {
+
+    /*
+    Score = Wd_D + Wc_C + Wn_N + Wh_H --- D = ping, C = res, N = network, H = history
+    Weight: 1 - 10 - 10 - 10
+     */
 
     //TODO: Weight should be dynamic
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
@@ -162,8 +165,6 @@ public class ScoreBasedMatchMaking extends MatchMakingModuleObject implements Ma
 
 
     /**
-     * Score = Wd_D + Wc_C + Wn_N + Wh_H --- D = ping, C = res, N = network, H = history
-     * Weight: 1 - 10 - 10 - 10
      * Calculate node score after get rid of the bad nodes. Used this when we do have to iterate all nodes in the list for match making.
      *
      * @param nodeResource node's available resource
@@ -173,6 +174,11 @@ public class ScoreBasedMatchMaking extends MatchMakingModuleObject implements Ma
      * @author Zero
      */
     private long getScore(long nodeResource, long nodeNetwork, long pingNumber, long nodeHistoryScore) {
+        /*
+        Score = Wd_D + Wc_C + Wn_N + Wh_H --- D = ping, C = res, N = network, H = history
+        Weight: 1 - 10 - 10 - 10
+         */
+
         //Initiate calculating variable
         long result;
 
@@ -188,7 +194,7 @@ public class ScoreBasedMatchMaking extends MatchMakingModuleObject implements Ma
     }
 
     /**
-     * -----------------------Get Ping between client & node-----------------------
+     * Get Ping between client and node.
      * This should be dynamic base on some short of triangulation if possible. Or just throw random number for now
      * <p>
      * Ver 0.1: Using 2 int numbers, and calculate the distance between them.

--- a/src/main/java/InfrastructureManager/Modules/NetworkStructure/ApplicationInstance.java
+++ b/src/main/java/InfrastructureManager/Modules/NetworkStructure/ApplicationInstance.java
@@ -1,46 +1,25 @@
 package InfrastructureManager.Modules.NetworkStructure;
 //States of the application
 
-/**
- * This class contains application information.
- *
- * @author Shankar Lokeshwara
- */
 public class ApplicationInstance {
 	enum State {RUNNING,COMPLETED,SUSPENDED,PAUSED}
 	private ApplicationType application; 
 	private State applicationState; 
 	
 
-	/**
-	* Parameterized constructor for class ApplicationInstance
-	* @param application 		application object
-	*/
 	public ApplicationInstance(ApplicationType application, State initialState) {
 		this.application = application;
 		this.applicationState = initialState;
 	}
 	
-	/**
-	 * Getter function
-	 * @return application
-	 */
 	public ApplicationType getApplicationType() {
 		return application;
 	}
 	
-	/**
-	 * Getter function
-	 * @return applicationState
-	 */
 	public State getApplicationState() {
 		return applicationState;
 	}
 		
-	/**
-	 * Setter function
-	 * @param applicationState
-	 */
 	public void setApplicationState(State applicationState) {
 		this.applicationState = applicationState;
 	}

--- a/src/main/java/InfrastructureManager/Modules/NetworkStructure/ApplicationInstanceDeviceRelation.java
+++ b/src/main/java/InfrastructureManager/Modules/NetworkStructure/ApplicationInstanceDeviceRelation.java
@@ -1,38 +1,18 @@
 package InfrastructureManager.Modules.NetworkStructure;
 
-/**
- * This class contains relationship between application and device information.
- *
- * @author Shankar Lokeshwara
- */
-
 public class ApplicationInstanceDeviceRelation {
 	private ApplicationInstance application;
 	private Device device;
 	
-	/**
-	* Parameterized constructor for class ApplicationInstanceDeviceRelation
-	* @param application 	application object
-	* @param device 		device object
-	*/
 	public ApplicationInstanceDeviceRelation(ApplicationInstance application,Device device) {
 		this.application = application;
 		this.device = device;
 	}
 	
-	/**
-	 * Getter function
-	 * @return application
-	 */
-	
 	public ApplicationInstance getApplication() {
 		return this.application;		
 	}
 	
-	/**
-	 * Getter function
-	 * @return device
-	 */
 	public Device getDevice() {
 		return this.device;		
 	}

--- a/src/main/java/InfrastructureManager/Modules/NetworkStructure/ApplicationType.java
+++ b/src/main/java/InfrastructureManager/Modules/NetworkStructure/ApplicationType.java
@@ -1,48 +1,25 @@
 package InfrastructureManager.Modules.NetworkStructure;
 
-/**
- * This class contains application requirements.
- *
- * @author Shankar Lokeshwara
- */
 public class ApplicationType {
 	private String applicationId; // Member variable to hold application ID.
 	private ComputeRequirements computeSpecification;
 	private NetworkRequirements networkSpecification;
 	
 	
-	/**
-	* Parameterized constructor for class ApplicationType
-	* @param applicationId 		applicationId as integer
-	* @param computeSpecification 		
-	* @param networkSpecification 		
-	*/
 	public ApplicationType(String applicationId,ComputeRequirements computeSpecification,NetworkRequirements networkSpecification) {
 		this.applicationId = applicationId;
 		this.computeSpecification = computeSpecification;
 		this.networkSpecification = networkSpecification;
 	}
 	
-	/**
-	 * Getter function
-	 * @return applicationId
-	 */
 	public String getApplicationId() {
 		return applicationId;
 	}
 	
-	/**
-	 * Getter function
-	 * @return computeSpecification
-	 */
 	public ComputeRequirements getComputeSpecification() {
 		return computeSpecification;
 	}
 	
-	/**
-	 * Getter function
-	 * @return networkSpecification
-	 */
 	public NetworkRequirements getNetworkSpecification() {
 		return networkSpecification;
 	}

--- a/src/main/java/InfrastructureManager/Modules/NetworkStructure/ComputeLimits.java
+++ b/src/main/java/InfrastructureManager/Modules/NetworkStructure/ComputeLimits.java
@@ -1,49 +1,25 @@
 package InfrastructureManager.Modules.NetworkStructure;
 
-/**
- * This class contains Computation limitation of the device.
- *
- * @author Shankar Lokeshwara
- */
 public class ComputeLimits {
 	private float cpuCount; // Number of CPU's available
 	private float gpuCount; // Number of GPU's available
 	private float memoryLimit; // Mega Bytes of memory available
 	
 	
-	/**
-	* Parameterized constructor for class ComputeLimits
-	* @param cpuCount 		float
-	* @param gpuCount 		float
-	* @param memoryLimit 	float
-	*/
-    public ComputeLimits(float cpuCount,float gpuCount, float memoryLimit) {
+	public ComputeLimits(float cpuCount,float gpuCount, float memoryLimit) {
         this.cpuCount = cpuCount;
         this.gpuCount = gpuCount;
         this.memoryLimit = memoryLimit;
     }
 	
-	/**
-	 * Getter function
-	 * @return cpuCount
-	 */
 	public float getCpuCount() {
 		return cpuCount;
 	}
-	
-	/**
-	 * Getter function
-	 * @return gpuCount
-	 */
 	
 	public float getGpuCount() {
 		return gpuCount;
 	}
 	
-	/**
-	 * Getter function
-	 * @return memoryLimit
-	 */
 	public float getMemoryLimit() {
 		return memoryLimit;
 	}

--- a/src/main/java/InfrastructureManager/Modules/NetworkStructure/ComputeRequirements.java
+++ b/src/main/java/InfrastructureManager/Modules/NetworkStructure/ComputeRequirements.java
@@ -1,49 +1,25 @@
 package InfrastructureManager.Modules.NetworkStructure;
 
 
-/**
- * This class contains Computation requirements of the application.
- *
- * @author Shankar Lokeshwara
- */
-
 public class ComputeRequirements {
 	private float requiredCpu;
 	private float requiredGpu;
 	private float requiredMemory;
 	
-	/**
-	* Parameterized constructor for class ComputeRequirements
-	* @param requiredCpu 		integer
-	* @param requiredGpu 		integer
-	* @param requiredMemory 	integer
-	*/
-    public ComputeRequirements(float requiredCpu,float requiredGpu, float requiredMemory) {
+	public ComputeRequirements(float requiredCpu,float requiredGpu, float requiredMemory) {
         this.requiredCpu = requiredCpu;
         this.requiredGpu = requiredGpu;
         this.requiredMemory = requiredMemory;
     }
 	
-	/**
-	 * Getter function
-	 * @return requiredCpu
-	 */
 	public float getRequiredCpu() {
 		return requiredCpu;
 	}
 	
-	/**
-	 * Getter function
-	 * @return requiredGpu
-	 */
 	public float getRequiredGpu() {
 		return requiredGpu;
 	}
 	
-	/**
-	 * Getter function
-	 * @return requiredMemory
-	 */
 	public float getRequiredMemory() {
 		return requiredMemory;
 	}

--- a/src/main/java/InfrastructureManager/Modules/NetworkStructure/Connection.java
+++ b/src/main/java/InfrastructureManager/Modules/NetworkStructure/Connection.java
@@ -1,45 +1,23 @@
 package InfrastructureManager.Modules.NetworkStructure;
-/**
- * This class contains connection information.
- *
- * @author Shankar Lokeshwara
- */
 
 public class Connection {
 	private String connectionId;
 	private NetworkLimits networkCapacity;
 	
    
-	/**
-	* Parameterized constructor for class Connection
-	* @param connectionId 		integer
-	* @param networkCapacity 		
-	*/
-    public Connection(String connectionId, NetworkLimits networkCapacity) {
+	public Connection(String connectionId, NetworkLimits networkCapacity) {
         this.connectionId = connectionId;
         this.networkCapacity = networkCapacity;
     }
     
-	/**
-	 * Getter function
-	 * @return connectionId
-	 */
 	public String getConnectionId() {
 		return connectionId;
 	}
 	
-	/**
-	 * Getter function
-	 * @return networkCapacity
-	 */
 	public NetworkLimits getNetworkCapacity() {
 		return networkCapacity;
 	}
 	
-	/**
-	 * Setter function
-	 * @param networkCapacity
-	 */
 	public void setNetworkCapacity(NetworkLimits networkCapacity) {
 		this.networkCapacity =  networkCapacity;
 	}

--- a/src/main/java/InfrastructureManager/Modules/NetworkStructure/Device.java
+++ b/src/main/java/InfrastructureManager/Modules/NetworkStructure/Device.java
@@ -1,9 +1,4 @@
 package InfrastructureManager.Modules.NetworkStructure;
-/**
- * This class contains Device information.
- *
- * @author Shankar Lokeshwara
- */
 
 
 public class Device {
@@ -13,65 +8,33 @@ public class Device {
 	private ComputeLimits computeLimits;
 	
    
-	/**
-	* Parameterized constructor of Device Class
-	* @param deviceId 		integer		
-	* @param deviceAddress
-	* @param deviceType
-	* @param computeLimits
-	*/
-    public Device(String deviceId,String deviceAddress, DeviceType deviceType,ComputeLimits computeLimits) {
+	public Device(String deviceId,String deviceAddress, DeviceType deviceType,ComputeLimits computeLimits) {
         this.deviceId = deviceId;
         this.deviceAddress = deviceAddress;
         this.deviceType = deviceType;
         this.computeLimits = computeLimits;
     }	
 	
-	/**
-	 * Getter function
-	 * @return deviceId
-	 */
 	public String getDeviceId() {
 		return deviceId;
 	}
-	
-	/**
-	 * Getter function
-	 * @return deviceAddress
-	 */
 	
 	public String getDeviceAddress() {
 		return deviceAddress;
 	}
 	
-	/**
-	 * Getter function
-	 * @return deviceType
-	 */
 	public DeviceType getDeviceType() {
 		return deviceType;
 	}
 	
-	/**
-	 * Getter function
-	 * @return computeLimits
-	 */
 	public ComputeLimits getComputeLimits() {
 		return computeLimits;
 	}
 	
-	/**
-	 * Setter function
-	 * @param deviceAddress
-	 */
 	public void setDeviceAddress(String deviceAddress) {
 		this.deviceAddress = deviceAddress;
 	}
 	
-	/**
-	 * Setter function
-	 * @param deviceAddress
-	 */
 	public void setComputeLimits(ComputeLimits computeLimits) {
 		this.computeLimits = computeLimits;
 	}

--- a/src/main/java/InfrastructureManager/Modules/NetworkStructure/DeviceLocationRelation.java
+++ b/src/main/java/InfrastructureManager/Modules/NetworkStructure/DeviceLocationRelation.java
@@ -1,37 +1,19 @@
 package InfrastructureManager.Modules.NetworkStructure;
-/**
- * This class contains relationship between device and location information.
- *
- * @author Shankar Lokeshwara
- */
 
 public class DeviceLocationRelation {
 	
 	private Device device;
 	private Location location;
 	
-	/**
-	* Parameterized constructor of Class DeviceLocationRelation 
-	* @param Device 				
-	* @param Location
-	*/
 	public DeviceLocationRelation(Device device,Location location) {
 		this.device = device;
 		this.location = location;		
 	}
 	
-	/**
-	 * Getter function
-	 * @return device
-	 */
 	public Device getDeviceLocation() {
 		return this.device;		
 	}
 	
-	/**
-	 * Getter function
-	 * @return location
-	 */
 	public Location getLocation() {
 		return this.location;		
 	}

--- a/src/main/java/InfrastructureManager/Modules/NetworkStructure/DeviceType.java
+++ b/src/main/java/InfrastructureManager/Modules/NetworkStructure/DeviceType.java
@@ -1,11 +1,5 @@
 package InfrastructureManager.Modules.NetworkStructure;
 
-/**
- * This class contains device types.
- *
- * @author Shankar Lokeshwara
- */
-
 public class DeviceType {
 	enum TypeId {UE,POA,FOG,EDGE,CLOUD,NONE} //Types of the device ID's
 	enum Mobility {MOVABLE,NONMOVABLE,NONE} //Types of devices based on mobility
@@ -14,37 +8,19 @@ public class DeviceType {
 	private Mobility mobilityType;
 	private String deviceName;
 	
-	/**
-	* Parameterized constructor for DeviceType Class
-	* @param TypeId 				
-	* @param mobilityType
-	* @param deviceName
-	*/
 	public DeviceType(TypeId typeIdentifier,Mobility mobilityType,String deviceName) {
 		this.typeIdentifier = typeIdentifier;
 		this.mobilityType = mobilityType;
 		this.deviceName = deviceName;
 	}
-	/**
-	 * Getter function
-	 * @return typeIdentifier
-	 */
 	public TypeId getTypeId()
     {
         return typeIdentifier;
     }
-	/**
-	 * Getter function
-	 * @return mobilityType
-	 */
 	public Mobility getMobility()
     {
         return mobilityType;
     }	
-	/**
-	 * Getter function
-	 * @return deviceName
-	 */
 	public String getDeviceName() {
         return deviceName;
     }

--- a/src/main/java/InfrastructureManager/Modules/NetworkStructure/Location.java
+++ b/src/main/java/InfrastructureManager/Modules/NetworkStructure/Location.java
@@ -1,67 +1,33 @@
 package InfrastructureManager.Modules.NetworkStructure;
 
 
-/**
- * This class contains location information.
- *
- * @author Shankar Lokeshwara
- */
-
 public class Location {
 	private String locationId;
 	private float latitude;
 	private float longitude;
 	
-	/**
-	* Parameterized constructor for Location Class
-	* @param locationId 				
-	* @param latitude
-	* @param longitude
-	*/
 	public Location(String locationId,float latitude,float longitude) {
 		this.locationId = locationId;
 		this.latitude = latitude;
 		this.longitude = longitude;
 	}
 	
-	/**
-	 * Getter function
-	 * @return locationId
-	 */
 	public String getLocationId() {
 		return locationId;
 	}
-	
-	/**
-	 * Getter function
-	 * @return latitude
-	 */
 	
 	public float getLatitude() {
 		return latitude;
 	}
 	
-	/**
-	 * Getter function
-	 * @return longitude
-	 */
-	
 	public float getLongitude() {
 		return longitude;
 	}
 	
-	/**
-	 * Setter function
-	 * @param latitude
-	 */
 	public void setLatitude(float latitude) {
 		this.latitude = latitude;
 	}
 	
-	/**
-	 * Setter function
-	 * @param longitude
-	 */
 	public void setLongitude(float longitude) {
 		this.longitude = longitude;
 	}	

--- a/src/main/java/InfrastructureManager/Modules/NetworkStructure/LocationConnectionRelation.java
+++ b/src/main/java/InfrastructureManager/Modules/NetworkStructure/LocationConnectionRelation.java
@@ -1,36 +1,18 @@
 package InfrastructureManager.Modules.NetworkStructure;
-/**
- * This class contains relationship between location and connection information.
- *
- * @author Shankar Lokeshwara
- */
 public class LocationConnectionRelation {
 	
 	private Connection connection;
 	private Location location;
 	
-	/**
-	* Parameterized constructor for LocationConnectionRelation Class
-	* @param connection 	
-	* @param location 			
-	*/
 	public LocationConnectionRelation(Connection connection,Location location) {
 		this.connection = connection;
 		this.location = location;
 	}
 	
-	/**
-	 * Getter function
-	 * @return location
-	 */
 	public Location getLocationRelation () {
 		return this.location;	
 	}
 	
-	/**
-	 * Getter function
-	 * @return connection
-	 */
 	public Connection getConnectionRelation () {
 		return this.connection;	
 	}

--- a/src/main/java/InfrastructureManager/Modules/NetworkStructure/Network.java
+++ b/src/main/java/InfrastructureManager/Modules/NetworkStructure/Network.java
@@ -7,12 +7,6 @@ import InfrastructureManager.Modules.NetworkStructure.Exception.NetworkModuleExc
 
 import java.util.List;
 
-/**
- * This class contains network information.
- *
- * @author Shankar Lokeshwara
- */
-
 public class Network {
 	enum Update {ADD,DELETE};
 	private final ObjectMapper mapper;
@@ -24,9 +18,6 @@ public class Network {
 	private List<LocationConnectionRelation> locationConnectionList;
 	private List<DeviceLocationRelation> deviceLocationList;
 
-	/**
-	 * Default constructor for Network Class
-	 */
 	public Network() {
 		this.mapper = new ObjectMapper();
 		deviceList = new ArrayList<>();
@@ -38,10 +29,6 @@ public class Network {
 		deviceLocationList = new ArrayList<>();
 	}
 
-	/**
-	 * Function to read JSON string and update network class
-	 * @param String
-	 */
 	public void loadNetwork(String readString) throws JsonProcessingException{
 
 		//New object created as the called object cannot be accessed as a whole. Therefore new object is created to update the calling object members with values from json string
@@ -50,10 +37,6 @@ public class Network {
 				);
 	}
 
-	/**
-	 * Function to update network class
-	 * @param Network object
-	 */
 	public void copyNetwork(Network network) {
 		this.deviceList = network.deviceList;
 		this.connectionList = network.connectionList;
@@ -65,10 +48,6 @@ public class Network {
 	}
 
 
-	/**
-	 * Function to save JSON string
-	 * @return String
-	 */
 	public String saveNetwork() throws InterruptedException{
 		try {
 			String json = this.mapper.writeValueAsString(this);
@@ -81,11 +60,6 @@ public class Network {
 	}
 
 
-	/**
-	 * Getter function to get a particular device from deviceList
-	 * @param deviceId
-	 * @return Device
-	 */
 	public Device getDeviceFromList(String deviceId)	{
 		int idx=0;
 		for (Object obj : this.deviceList) {
@@ -98,11 +72,6 @@ public class Network {
 		return this.deviceList.get(idx);
 	}
 
-	/**
-	 * Function to update a particular device in deviceList
-	 * @param Device
-	 * @param UpdateType // ADD or DELETE
-	 */
 	public void updateDeviceList(Device device,Network.Update update){
 		if (update == Network.Update.ADD)
 		{
@@ -121,11 +90,6 @@ public class Network {
 
 
 
-	/**
-	 * Getter function to get a particular connection from connectionList
-	 * @param ConnectionId
-	 * @return Connection
-	 */
 	public Connection getConnectionFromList(String ConnectionId)	{
 		int idx=0;
 		for (Object obj : this.connectionList) {
@@ -138,11 +102,6 @@ public class Network {
 		return this.connectionList.get(idx);
 	}
 
-	/**
-	 * Function to update a particular connection in connectionList
-	 * @param Connection
-	 * @param UpdateType // ADD or DELETE
-	 */
 	public void updateConnectionList(Connection connection,Network.Update update){
 		if (update == Network.Update.ADD)
 		{
@@ -159,11 +118,6 @@ public class Network {
 		}
 	}
 
-	/**
-	 * Getter function to get a particular location from locationList
-	 * @param LocationId
-	 * @return Location
-	 */
 	public Location getLocationFromList(String LocationId)	{
 		int idx=0;
 		for (Object obj : this.locationList) {
@@ -176,11 +130,6 @@ public class Network {
 		return this.locationList.get(idx);
 	}
 
-	/**
-	 * Function to update a particular location in locationList
-	 * @param Location
-	 * @param UpdateType // ADD or DELETE
-	 */
 	public void updateLocationList(Location location,Network.Update update){
 		if (update == Network.Update.ADD)
 		{
@@ -198,11 +147,6 @@ public class Network {
 	}
 	
 	
-	/**
-	 * Getter function to get a particular application from applicationList
-	 * @param applicationId
-	 * @return ApplicationInstance
-	 */
 	public ApplicationInstance getApplicationInstanceFromList(String ApplicationId)	{
 		int idx=0;
 		for (Object obj : this.applicationList) {
@@ -215,11 +159,6 @@ public class Network {
 		return this.applicationList.get(idx);
 	}
 
-	/**
-	 * Function to update a particular application in applicationList
-	 * @param application
-	 * @param UpdateType // ADD or DELETE
-	 */
 	public void updateApplicationInstanceList(ApplicationInstance application,Network.Update update){
 		if (update == Network.Update.ADD)
 		{
@@ -236,50 +175,26 @@ public class Network {
 		}
 	}
 
-	/**
-	 * Getter function
-	 * @return applicationDeviceList
-	 */
 	public List<ApplicationInstanceDeviceRelation> getApplicationDeviceList() {
 		return applicationDeviceList;
 	}
 
-	/**
-	 * Getter function
-	 * @return locationConnectionList
-	 */
 	public List<LocationConnectionRelation> getLocationConnectionList() {
 		return locationConnectionList;
 	}
 
-	/**
-	 * Getter function
-	 * @return deviceLocationList
-	 */
 	public List<DeviceLocationRelation> getDeviceLocationList() {
 		return deviceLocationList;
 	}
 
-	/**
-	 * Setter function
-	 * @param applicationDeviceList
-	 */
 	public void setApplicationDeviceList(List<ApplicationInstanceDeviceRelation> applicationDeviceList) {
 		this.applicationDeviceList = applicationDeviceList;
 	}
 
-	/**
-	 * Setter function
-	 * @param locationConnectionList
-	 */
 	public void setLocationConnectionList(List<LocationConnectionRelation> locationConnectionList) {
 		this.locationConnectionList = locationConnectionList;
 	}
 
-	/**
-	 * Setter function
-	 * @param deviceLocationList
-	 */
 	public void setDeviceLocationList(List<DeviceLocationRelation> deviceLocationList) {
 		this.deviceLocationList = deviceLocationList;
 	}

--- a/src/main/java/InfrastructureManager/Modules/NetworkStructure/NetworkLimits.java
+++ b/src/main/java/InfrastructureManager/Modules/NetworkStructure/NetworkLimits.java
@@ -1,23 +1,11 @@
 package InfrastructureManager.Modules.NetworkStructure;
 
-/**
- * This class contains relationship between NetworkLimits information.
- *
- * @author Shankar Lokeshwara
- */
-
 public class NetworkLimits {
 	private float latency;
 	private float jitter;
 	private double throughput;
 	private double packetLoss;
 	
-	/**
-	* Parameterized constructor for NetworkLimits Class
-	* @param latency 	
-	* @param throughput 
-	* @param packetLoss 			
-	*/
 	public NetworkLimits(float latency,float jitter,double throughput,double packetLoss) {
 		this.latency = latency;
 		this.jitter = jitter;
@@ -25,34 +13,18 @@ public class NetworkLimits {
 		this.packetLoss = packetLoss;
 	}
 	
-	/**
-	 * Getter function
-	 * @return latency
-	 */
 	public float getLatency() {
 		return latency;
 	}
 	
-	/**
-	 * Getter function
-	 * @return jitter
-	 */
 	public float getJitter() {
 		return jitter;
 	}
 	
-	/**
-	 * Getter function
-	 * @return throughput
-	 */
 	public double getThroughput() {
 		return throughput;
 	}
 	
-	/**
-	 * Getter function
-	 * @return packetLoss
-	 */
 	public double getPacketLoss() {
 		return packetLoss;
 	}

--- a/src/main/java/InfrastructureManager/Modules/NetworkStructure/NetworkModule.java
+++ b/src/main/java/InfrastructureManager/Modules/NetworkStructure/NetworkModule.java
@@ -2,11 +2,6 @@ package InfrastructureManager.Modules.NetworkStructure;
 import InfrastructureManager.ModuleManagement.PlatformModule;
 import InfrastructureManager.ModuleManagement.RawData.ModuleConfigData;
 import InfrastructureManager.Modules.NetworkStructure.RawData.NetworkModuleConfigData;
-/**
- * This class contains NetworkModule information.
- *
- * @author Shankar Lokeshwara
- */
 public class NetworkModule extends PlatformModule implements GlobalVarAccessNetworkModule{
 
     public NetworkModule() {

--- a/src/main/java/InfrastructureManager/Modules/NetworkStructure/NetworkRequirements.java
+++ b/src/main/java/InfrastructureManager/Modules/NetworkStructure/NetworkRequirements.java
@@ -1,23 +1,11 @@
 package InfrastructureManager.Modules.NetworkStructure;
 
-/**
- * This class contains NetworkRequirements .
- *
- * @author Shankar Lokeshwara
- */
-
 public class NetworkRequirements {
 	private float requiredLatency;
 	private float requiredJitter;
 	private double requiredThroughput;
 	private double requiredPacketLoss;
 	
-	/**
-	* Parameterized constructor for NetworkRequirements Class
-	* @param requiredLatency 	
-	* @param requiredThroughput 
-	* @param requiredPacketLoss 			
-	*/
 	public NetworkRequirements(float requiredLatency,float requiredJitter,double requiredThroughput,double requiredPacketLoss) {
 		this.requiredLatency = requiredLatency;
 		this.requiredJitter = requiredJitter;
@@ -25,34 +13,18 @@ public class NetworkRequirements {
 		this.requiredPacketLoss = requiredPacketLoss;
 	}
 	
-	/**
-	 * Getter function
-	 * @return requiredLatency
-	 */
 	public float getRequiredLatency() {
 		return requiredLatency;
 	}
 	
-	/**
-	 * Getter function
-	 * @return requiredJitter
-	 */
 	public float getRequiredJitter() {
 		return requiredJitter;
 	}
 	
-	/**
-	 * Getter function
-	 * @return requiredThroughput
-	 */
 	public double getRequiredThroughput() {
 		return requiredThroughput;
 	}
 	
-	/**
-	 * Getter function
-	 * @return requiredPacketLoss
-	 */
 	public double getRequiredPacketLoss() {
 		return requiredPacketLoss;
 	}


### PR DESCRIPTION
I fixed the errors in the javadocs that were messing up the automatic deployment.

Fixed a couple of errors in CommandSet and ScoreBasedMatchMaking 

Most of errors and warnings were in the Network Package (Comments with `@param` arguments not corresponding to the ones in the method for some reason). In the case of that package, I just left everything without documentation, and figured once the module is finished, the documentation that Shankar makes just merges in.

I have tested the javadoc via gradle locally, and it works, so now we should not have an issue