### PR TITLE
Automated Test Workflow Correction

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Build javadocs with gradle (To test correct documentation)
       run: ./gradlew javadoc
     - name: Delete javadocs folder
-      run: .\gradlew cleanJavadoc
+      run: ./gradlew cleanJavadoc
     - name: Cleanup Gradle Cache
         # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
         # Restoring these files from a GitHub Actions cache might cause problems for future builds.


### PR DESCRIPTION
In the automatic testing workflow, I made a mistake in the command to delete the javadocs folder after creating them. 

It was causing tests to always fail

I fixed it