### PR TITLE
Docker deployment

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,40 @@
+name: Build and push docker image
+on:
+  push:
+    branches:
+      - master
+jobs:
+  deploy-on-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - name: Set up JDK 14
+        uses: actions/setup-java@v1
+        with:
+          java-version: 14
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Build jar, build image and push with gradle
+        run: ./gradlew dockerPushDockerHub
+      - name: Cleanup Gradle Cache
+          # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
+          # Restoring these files from a GitHub Actions cache might cause problems for future builds.
+        run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock
+          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /.idea/
 /build
 /out/
-Dockerfile
 src/test/resources/testScenario.json
 /UTF16
 /EdgeDiagnosticsApp/CommonUtils/build/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@
 Dockerfile
 src/test/resources/testScenario.json
 /UTF16
+/EdgeDiagnosticsApp/CommonUtils/build/
+/EdgeDiagnosticsApp/CommonUtils/out/
+/EdgeDiagnosticsApp/DiagnosticsClient/build/
+/EdgeDiagnosticsApp/DiagnosticsClient/out/
+/EdgeDiagnosticsApp/DiagnosticsServer/build/
+/EdgeDiagnosticsApp/DiagnosticsServer/out/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,8 @@
-#Docker file to create images from fatJar custom task in gradle multi-project build
-#Use gradle multistage build, in the first stage install gradle and run the jar task
-#FROM gradle:6.6-jdk14-hotspot AS build
-#COPY --chown=gradle:gradle . /home/gradle/src
-#WORKDIR /home/gradle/src
-#RUN gradle fatJar
-
-#Second stage, copy the generated jar into a new lightweight image with only JRE
+#Docker file to create images from fatJar custom task
 FROM adoptopenjdk/openjdk15:jre-15.0.2_7-alpine
 EXPOSE 4567
 RUN mkdir /EdgeDiagnostics
+#copy the generated jar into a lightweight image with only JRE
 COPY *.jar /EdgeDiagnostics/platform.jar
 WORKDIR /EdgeDiagnostics
 ENTRYPOINT ["java", "-jar","./platform.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+#Docker file to create images from fatJar custom task in gradle multi-project build
+#Use gradle multistage build, in the first stage install gradle and run the jar task
+FROM gradle:6.6-jdk14-hotspot AS build
+COPY --chown=gradle:gradle . /home/gradle/src
+WORKDIR /home/gradle/src
+RUN gradle fatJar
+
+#Second stage, copy the generated jar into a new lightweight image with only JRE
+FROM adoptopenjdk/openjdk14:jre-14.0.2_12-alpine
+RUN mkdir /EdgeDiagnostics
+COPY --from=build /home/gradle/src/build/libs/*.jar /EdgeDiagnostics/platform.jar
+COPY ./Scenarios/* /EdgeDiagnostics/Scenarios/
+WORKDIR /EdgeDiagnostics
+ENTRYPOINT ["java", "-jar","./platform.jar"]
+#Use this to put arguments that pass as default to the app, otherwise pass them in docker build
+CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 #Docker file to create images from fatJar custom task in gradle multi-project build
 #Use gradle multistage build, in the first stage install gradle and run the jar task
-FROM gradle:6.6-jdk14-hotspot AS build
-COPY --chown=gradle:gradle . /home/gradle/src
-WORKDIR /home/gradle/src
-RUN gradle fatJar
+#FROM gradle:6.6-jdk14-hotspot AS build
+#COPY --chown=gradle:gradle . /home/gradle/src
+#WORKDIR /home/gradle/src
+#RUN gradle fatJar
 
 #Second stage, copy the generated jar into a new lightweight image with only JRE
-FROM adoptopenjdk/openjdk14:jre-14.0.2_12-alpine
+FROM adoptopenjdk/openjdk15:jre-15.0.2_7-alpine
+EXPOSE 4567
 RUN mkdir /EdgeDiagnostics
-COPY --from=build /home/gradle/src/build/libs/*.jar /EdgeDiagnostics/platform.jar
-COPY ./Scenarios/* /EdgeDiagnostics/Scenarios/
+COPY *.jar /EdgeDiagnostics/platform.jar
 WORKDIR /EdgeDiagnostics
 ENTRYPOINT ["java", "-jar","./platform.jar"]
 #Use this to put arguments that pass as default to the app, otherwise pass them in docker build

--- a/Scenarios/dummy.json
+++ b/Scenarios/dummy.json
@@ -1,0 +1,16 @@
+{
+  "eventList": [
+    {
+      "command": "deploy_application",
+      "executionTime": 1000
+    },
+    {
+      "command": "update_gui",
+      "executionTime": 3000
+    },
+    {
+      "command": "node_request",
+      "executionTime": 10000
+    }
+  ]
+}

--- a/build.gradle
+++ b/build.gradle
@@ -5,23 +5,29 @@ plugins {
 }
 application {
     //Necessary configuration for application plugin, path to the main method
-    mainClassName 'InfrastructureManager.Master'
+    mainClassName = 'InfrastructureManager.Master'
 }
 
 group 'de.fh-dortmund'
 version '0.5'
 
-jar {
-    //Include the Main-Class Attribute so that the generated jar is executable using java -jar
-    manifest {
-        attributes "Main-Class": "InfrastructureManager.Master"
+task printInfo() {
+    doLast {
+        sourceSets.main.runtimeClasspath.files.each {
+            print "  " + it.path + "\n"
+        }
     }
 }
 
-jar {
-    //jar for Applications
+task fatJar(type: Jar) {
     manifest {
-        attributes "Main-Class": "Application.DockerApp"
+        attributes "Main-Class": mainClassName
+    }
+    from sourceSets.main.output
+
+    dependsOn configurations.runtimeClasspath
+    from {
+        configurations.runtimeClasspath.findAll { it.name.endsWith('jar') }.collect { zipTree(it) }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     //Application plugin which implicitly includes java plugin
     //Makes the app runnable on CL (gradle run)
     id 'application'
+    id "com.palantir.docker" version "0.26.0"
 }
 application {
     //Necessary configuration for application plugin, path to the main method
@@ -11,13 +12,7 @@ application {
 group 'de.fh-dortmund'
 version '0.5'
 
-task printInfo() {
-    doLast {
-        sourceSets.main.runtimeClasspath.files.each {
-            print "  " + it.path + "\n"
-        }
-    }
-}
+
 
 task fatJar(type: Jar) {
     manifest {
@@ -29,6 +24,13 @@ task fatJar(type: Jar) {
     from {
         configurations.runtimeClasspath.findAll { it.name.endsWith('jar') }.collect { zipTree(it) }
     }
+}
+
+docker {
+    dependsOn fatJar
+    name "${project.name.toLowerCase()}:${project.version}"
+    dockerfile file('Dockerfile')
+    files tasks.fatJar.outputs.files
 }
 
 run {

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ docker {
     name "${project.name.toLowerCase()}:${project.version}"
     dockerfile file('Dockerfile')
     files tasks.fatJar.outputs.files
-    tag 'JuanDockerHub', "jpcr3108/${project.name.toLowerCase()}:${project.version}"
+    tag 'DockerHub', "edgelabfh/${project.name.toLowerCase()}:${project.version}"
 }
 
 run {

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ docker {
     name "${project.name.toLowerCase()}:${project.version}"
     dockerfile file('Dockerfile')
     files tasks.fatJar.outputs.files
+    tag 'JuanDockerHub', "jpcr3108/${project.name.toLowerCase()}:${project.version}"
 }
 
 run {

--- a/src/main/java/InfrastructureManager/Configuration/ModuleManagerConfigurator.java
+++ b/src/main/java/InfrastructureManager/Configuration/ModuleManagerConfigurator.java
@@ -2,11 +2,13 @@ package InfrastructureManager.Configuration;
 
 import InfrastructureManager.Configuration.Exception.ConfigurationException;
 import InfrastructureManager.Configuration.RawData.ModulesConfigurationFileData;
+import InfrastructureManager.Master;
 import InfrastructureManager.ModuleManagement.ModuleManager;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Configurator class for the {@link ModuleManager}, that reads the values in the configuration file
@@ -16,6 +18,27 @@ import java.io.IOException;
 public class ModuleManagerConfigurator {
 
     private final ModuleManager manager;
+
+    /**
+     * Constructor of the class. Uses an {@link ObjectMapper} object to read data from the default configuration file,
+     * and create an object that represents that data of the type {@link ModulesConfigurationFileData}.
+     * With this object, it creates and initializes a {@link ModuleManager}.
+     * @throws ConfigurationException If an error occurs while reading the file or parsing it from JSON.
+     */
+    public ModuleManagerConfigurator() throws ConfigurationException {
+        ObjectMapper mapper = new ObjectMapper();
+        manager = new ModuleManager();
+        String path = Master.DEFAULT_CONFIG_PATH;
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream(path))
+        {
+            //Map the contents of the JSON file to a java object and initialize the manager with it.
+            manager.initialize(mapper.readValue(in, ModulesConfigurationFileData.class));
+
+            //manager.initialize(mapper.readValue(configFile, ModulesConfigurationFileData.class));
+        } catch (IOException e) {
+            throw new ConfigurationException("Error while reading JSON Config File",e);
+        }
+    }
 
     /**
      * Constructor of the class. Uses an {@link ObjectMapper} object to read data from a configuration file,

--- a/src/main/java/InfrastructureManager/Master.java
+++ b/src/main/java/InfrastructureManager/Master.java
@@ -8,6 +8,7 @@ import InfrastructureManager.ModuleManagement.ModuleManager;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Master Class of the Infrastructure Manager, singleton class.
@@ -19,7 +20,7 @@ import java.util.List;
  */
 public class Master {
 
-    private static final String DEFAULT_CONFIG_PATH = "src/main/resources/Configuration.json";
+    public static final String DEFAULT_CONFIG_PATH = "Configuration.json";
     private static Master instance = null;
 
     private ModuleManager manager;
@@ -30,7 +31,12 @@ public class Master {
      * @throws ConfigurationException if an error occurs while parsing the file or configuring the module manager
      */
     public void configure(String configPath) throws ConfigurationException {
-        ModuleManagerConfigurator configurator = new ModuleManagerConfigurator(configPath);
+        ModuleManagerConfigurator configurator;
+        if (!(configPath == null)) {
+            configurator = new ModuleManagerConfigurator(configPath);
+        } else {
+            configurator = new ModuleManagerConfigurator();
+        }
         manager = configurator.getConfiguredManager();
     }
 
@@ -100,7 +106,7 @@ public class Master {
                 }
             }
         }
-        return DEFAULT_CONFIG_PATH;
+        return null;
     }
 
     public static void main(String[] args) {

--- a/src/main/resources/Configuration.json
+++ b/src/main/resources/Configuration.json
@@ -1,7 +1,7 @@
 {
   "modules": [
     {"type": "ConsoleModule", "name": "console"},
-    {"type": "ScenarioModule", "name": "dummy", "path": "src/main/resources/scenarios/dummy.json"},
+    {"type": "ScenarioModule", "name": "dummy", "path": "Scenarios/dummy.json"},
     {"type": "UtilityModule", "name": "util"},
     {
       "type" : "RESTModule",

--- a/src/test/resources/ManualTestResources/Docker Deployment/commands.md
+++ b/src/test/resources/ManualTestResources/Docker Deployment/commands.md
@@ -1,0 +1,33 @@
+# Deploying the platform as a docker container
+
+## Locally
+
+Using the Dockerfile located in `./Dockerfile`, calling the command
+```
+gradle docker
+```
+Will generate a docker image and push it to the local docker cache. To do this, the task will make use of 
+the `fatJar` task to generate an uberJar and pass it to the image.
+To check it run `docker image ls --all`
+
+
+To run the image, different parameters should be used according to what is required.
+
+```
+docker run -it -p 4567:4567 --name <container_name> edge_diagnostic_platform:0.5
+```
+Runs the platform with the default configuration (`src/main/resources/Configuration.json`)
+
+```
+docker run -it -p 4567:4567 -v C:\Users\jpcr3\Desktop\Projects\FH-Dortmund\Edge-Diagnostic-Platform\Scenarios:/EdgeDiagnostics/Scenarios --name diagnostics edge-diagnostic-platform:0.5
+```
+Runs the platform with the default configuration and passes a folder in which scenarios are included, so
+the platform can read them
+
+```
+docker run -it -p 4567:4567 -v C:\Users\jpcr3\Desktop\Projects\FH-Dortmund\Edge-Diagnostic-Platform\Scenarios:/EdgeDiagnostics/Scenarios -v C:\Users\jpcr3\Desktop\Projects\FH-Dortmund\Edge-Diagnostic-Platform\Configurations:/EdgeDiagnostics/Configurations --name <container_name> edge-diagnostic-platform:0.5 -c Configurations/UtilityModuleTestConfiguration.json
+```
+Runs the platform, and mounts a folder for Scenarios and one for Configurations. The argument `Configurations/UtilityModuleTestConfiguration.json`
+tells the platform to start with the custom configuration located in the mounted folder.
+
+

--- a/src/test/resources/Modules/Utility/UtilityModuleTestConfiguration.json
+++ b/src/test/resources/Modules/Utility/UtilityModuleTestConfiguration.json
@@ -9,7 +9,7 @@
       "in" : "console.in",
       "out" : "console.out",
       "commands" : {
-        "test $param" : "console $param"
+        "test $param" : "console oe $param"
       }
     },
     {


### PR DESCRIPTION
Pull request to solve #103 

### New Tasks
As of right now, the following is added to the gradle project:
- A `fatJar` task that creates a  jar file for the platform that includes all the dependencies.
- A `docker` task that based on the following dockerfile, builds a docker image and passes the generated jar (This one calls `fatJar` automatically)

    ```dockerfile
    #Docker file to create images from fatJar custom task
    FROM adoptopenjdk/openjdk15:jre-15.0.2_7-alpine
    EXPOSE 4567
    RUN mkdir /EdgeDiagnostics
    #copy the generated jar into a lightweight image with only JRE
    COPY *.jar /EdgeDiagnostics/platform.jar
    WORKDIR /EdgeDiagnostics
    ENTRYPOINT ["java", "-jar","./platform.jar"]
    #Use this to put arguments that pass as default to the app, otherwise pass them in docker build
    CMD []
    ```
- Configurable `dockerPush` tasks. For each of the declared repositories in the `tag` section in the gradle build file, a task is created. In the current commit, a repository in my docker hub account is used and named `JuanDockerHub`. Calling the task `gradle dockerPushJuanDockerHub`  then pushes the image to the repository (Requires previous login)


### Running the docker image
With respect to working with the image:

To run the image, different parameters should be used according to what is required.

```
docker run -it -p 4567:4567 --name <container_name> edge_diagnostic_platform:0.5
```
Runs the platform with the default configuration (`src/main/resources/Configuration.json`)

```
docker run -it -p 4567:4567 -v C:\Users\jpcr3\Desktop\Projects\FH-Dortmund\Edge-Diagnostic-Platform\Scenarios:/EdgeDiagnostics/Scenarios --name diagnostics edge-diagnostic-platform:0.5
```
Runs the platform with the default configuration and passes a folder in which scenarios are included, so
the platform can read them. In this case, the path for the scenarios shoulb be specified in the config file in the container context (Is easier if the two folders are called the same)

```
docker run -it -p 4567:4567 -v C:\Users\jpcr3\Desktop\Projects\FH-Dortmund\Edge-Diagnostic-Platform\Scenarios:/EdgeDiagnostics/Scenarios -v C:\Users\jpcr3\Desktop\Projects\FH-Dortmund\Edge-Diagnostic-Platform\Configurations:/EdgeDiagnostics/Configurations --name <container_name> edge-diagnostic-platform:0.5 -c Configurations/UtilityModuleTestConfiguration.json
```
Runs the platform, and mounts a folder for Scenarios and one for Configurations. The argument `Configurations/UtilityModuleTestConfiguration.json`
tells the platform to start with the custom configuration located in the mounted folder.

Another folder can also be passed to store files generated by a `fileOutput` for example. (Mounting a volume is biderectional)

### Missing

Still missing are:
- Defining repositories to which we want to push (Maybe create a FH-Edge-Lab docker hub account, or setting up a self-hosted repo in the university)
- Getting credentials for the repos (Username and Password)
- Github Actions to perform the process on pushes to master (Also requires credentials to the repos)

@alyhasansakr What do you think about the repos?
