### PR TITLE
Get outputs hot fix

### DIFF
--- a/src/main/java/InfrastructureManager/Modules/REST/Output/GETOutput.java
+++ b/src/main/java/InfrastructureManager/Modules/REST/Output/GETOutput.java
@@ -90,14 +90,10 @@ public class GETOutput extends RESTModuleObject implements PlatformOutput {
 
     /**
      * Adds a given JSON body to be outputted.
-     * Checks first if the route has been created (Output is activated)
      *
      * @param jsonBody JSON body that will be a GET resource
      */
     protected void addResource(String jsonBody) {
-        /*if (!this.isActivated) {
-            this.activate();
-        }*/
         this.toSend = jsonBody;
     }
 }

--- a/src/main/java/InfrastructureManager/Modules/REST/Output/GETOutput.java
+++ b/src/main/java/InfrastructureManager/Modules/REST/Output/GETOutput.java
@@ -76,7 +76,7 @@ public class GETOutput extends RESTModuleObject implements PlatformOutput {
      * the REST server is already running.
      * Only runs once at the beginning
      */
-    protected void activate() {
+    public void activate() {
         try {
             RestServerRunner.serverCheck.acquire();
             get(this.URL, this.GETHandler);
@@ -95,9 +95,9 @@ public class GETOutput extends RESTModuleObject implements PlatformOutput {
      * @param jsonBody JSON body that will be a GET resource
      */
     protected void addResource(String jsonBody) {
-        if (!this.isActivated) {
+        /*if (!this.isActivated) {
             this.activate();
-        }
+        }*/
         this.toSend = jsonBody;
     }
 }

--- a/src/main/java/InfrastructureManager/Modules/REST/Output/ParametrizedGETOutput.java
+++ b/src/main/java/InfrastructureManager/Modules/REST/Output/ParametrizedGETOutput.java
@@ -60,7 +60,7 @@ public class ParametrizedGETOutput extends GETOutput {
      * Only runs once at the beginning
      */
     @Override
-    protected void activate() {
+    public void activate() {
         this.GETHandler = (Request request, Response response) -> {
             response.type("application/json");
             String parameterFromRequest = request.params(":" + this.parameter);
@@ -83,9 +83,9 @@ public class ParametrizedGETOutput extends GETOutput {
      * @param jsonBody JSON body that will be a GET resource
      */
     protected void addResource(String parameter, String jsonBody) {
-        if (!this.isActivated) {
+        /*if (!this.isActivated) {
             this.activate();
-        }
+        }*/
         this.info.put(parameter, jsonBody);
     }
 }

--- a/src/main/java/InfrastructureManager/Modules/REST/Output/ParametrizedGETOutput.java
+++ b/src/main/java/InfrastructureManager/Modules/REST/Output/ParametrizedGETOutput.java
@@ -78,14 +78,10 @@ public class ParametrizedGETOutput extends GETOutput {
 
     /**
      * Adds a given JSON body to be outputted.
-     * Checks first if the route has been created (Output is activated)
      * @param parameter Parameter value to which the jsonBody is related
      * @param jsonBody JSON body that will be a GET resource
      */
     protected void addResource(String parameter, String jsonBody) {
-        /*if (!this.isActivated) {
-            this.activate();
-        }*/
         this.info.put(parameter, jsonBody);
     }
 }

--- a/src/main/java/InfrastructureManager/Modules/REST/RESTModule.java
+++ b/src/main/java/InfrastructureManager/Modules/REST/RESTModule.java
@@ -57,7 +57,8 @@ public class RESTModule extends PlatformModule {
     }
 
     /**
-     * Starts the module and additionally starts the REST server.
+     * Starts the module and additionally starts the REST server. It also activates the outputs, so
+     * the paths defined by them are valid as soon as the REST server starts
      */
     @Override
     public void start() {

--- a/src/main/java/InfrastructureManager/Modules/REST/RESTModule.java
+++ b/src/main/java/InfrastructureManager/Modules/REST/RESTModule.java
@@ -3,6 +3,7 @@ package InfrastructureManager.Modules.REST;
 import InfrastructureManager.ModuleManagement.PlatformModule;
 import InfrastructureManager.ModuleManagement.RawData.ModuleConfigData;
 import InfrastructureManager.Modules.REST.Exception.Server.ServerNotConfiguredException;
+import InfrastructureManager.Modules.REST.Output.GETOutput;
 import InfrastructureManager.Modules.REST.RawData.RESTModuleConfigData;
 
 /**
@@ -61,6 +62,10 @@ public class RESTModule extends PlatformModule {
     @Override
     public void start() {
         startServerThread();
+        this.getOutputs().forEach( o -> {
+            GETOutput output = (GETOutput) o;
+            output.activate();
+        });
         super.start();
     }
 

--- a/src/test/java/InfrastructureManager/Modules/REST/InputUnitTests/POSTInputTests.java
+++ b/src/test/java/InfrastructureManager/Modules/REST/InputUnitTests/POSTInputTests.java
@@ -9,6 +9,7 @@ import InfrastructureManager.Modules.REST.RESTModule;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -105,5 +106,11 @@ public class POSTInputTests {
         Assert.assertEquals(500, response.getStatusCode());
         Assert.assertEquals(expected, response.asString());
         thread.interrupt();
+    }
+
+    @AfterClass
+    public static void close() throws ModuleManagerException {
+        Master.getInstance().getManager().exitAllModules();
+        Master.resetInstance();
     }
 }

--- a/src/test/java/InfrastructureManager/Modules/REST/OutputUnitTests/GETOutputTests.java
+++ b/src/test/java/InfrastructureManager/Modules/REST/OutputUnitTests/GETOutputTests.java
@@ -11,6 +11,7 @@ import InfrastructureManager.Modules.REST.Output.ParametrizedGETOutput;
 import InfrastructureManager.Modules.REST.RESTModule;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.RequestSpecification;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -22,10 +23,17 @@ public class GETOutputTests {
 
     private static RequestSpecification requestSpec;
     public static final String JSONExample = "{\"name\":\"example\",\"number\":874}";
-    private final RESTModule module = new RESTModule();
-    private final GETOutput get1 = new GETOutput(module,"get1","/rest/get_test");
-    private final ParametrizedGETOutput get2 = new ParametrizedGETOutput(module,"get2",
-            "/rest/get_test2/:id","id");
+    private static RESTModule module;
+    private final GETOutput get1 = getOutput("rest.get1");
+    private final ParametrizedGETOutput get2 = (ParametrizedGETOutput) getOutput("rest.get2");
+
+    private GETOutput getOutput(String name) {
+        return module.getOutputs().stream()
+                .map(o -> (GETOutput) o)
+                .filter(o -> o.getName().equals(name))
+                .findFirst()
+                .orElseThrow();
+    }
 
     @BeforeClass
     public static void setUpMasterAndStartServer() throws ModuleNotFoundException, ConfigurationException, ModuleManagerException {
@@ -39,6 +47,11 @@ public class GETOutputTests {
         Master.resetInstance();
         Master.getInstance().configure("src/test/resources/Modules/REST/RESTTestConfiguration.json");
         Master.getInstance().getManager().startModule("rest");
+        module = (RESTModule) Master.getInstance().getManager().getModules().stream()
+                .filter(m -> m.getName().equals("rest"))
+                .findFirst()
+                .orElseThrow();
+
     }
 
     @Test
@@ -46,7 +59,19 @@ public class GETOutputTests {
         String path = "/rest/get_test";
         get1.execute("toGET resource " + JSONExample);
         String responseBody = given().spec(requestSpec).get(path).asString();
-        Assert.assertEquals(responseBody,JSONExample);
+        Assert.assertEquals(JSONExample, responseBody);
+    }
+
+    @Test
+    public void beforeCreatingResourceValidPathReturnsEmptyString() throws RESTOutputException {
+        GETOutput get3 = getOutput("rest.get3");
+        String path = "/rest/get_test3";
+        String expected1 = "";
+        String responseBody = given().spec(requestSpec).get(path).asString();
+        Assert.assertEquals(expected1, responseBody);
+        get3.execute("toGET resource " + JSONExample);
+        responseBody = given().spec(requestSpec).get(path).asString();
+        Assert.assertEquals(JSONExample, responseBody);
     }
 
     @Test
@@ -61,29 +86,35 @@ public class GETOutputTests {
     @Test
     public void InGenericOutputIncompleteCommandThrowsException() {
         String command = "toGET resource"; //Missing the json body
-        String expected = "Arguments missing for command " + command + " to REST Output get1";
+        String expected = "Arguments missing for command " + command + " to REST Output rest.get1";
         assertException(RESTOutputException.class,expected,() -> get1.execute(command));
     }
 
     @Test
     public void InGenericOutputInvalidCommandThrowsException() {
         String command = "toGET notACommand";
-        String expected = "Invalid command notACommand for REST output get1";
+        String expected = "Invalid command notACommand for REST output rest.get1";
         assertException(RESTOutputException.class, expected, () -> get1.execute(command));
     }
 
     @Test
     public void InParameterOutputIncompleteCommandThrowsException() {
         String command = "toGET resource"; //Missing the json body
-        String expected = "Arguments missing for command " + command + " to REST Output get2";
+        String expected = "Arguments missing for command " + command + " to REST Output rest.get2";
         assertException(RESTOutputException.class,expected,() -> get2.execute(command));
     }
 
     @Test
     public void InParameterOutputInvalidCommandThrowsException() {
         String command = "toGET notACommand";
-        String expected = "Invalid command notACommand for REST output get2";
+        String expected = "Invalid command notACommand for REST output rest.get2";
         assertException(RESTOutputException.class, expected, () -> get2.execute(command));
+    }
+
+    @AfterClass
+    public static void close() throws ModuleManagerException {
+        Master.getInstance().getManager().exitAllModules();
+        Master.resetInstance();
     }
 
 }

--- a/src/test/resources/Modules/REST/RESTTestConfiguration.json
+++ b/src/test/resources/Modules/REST/RESTTestConfiguration.json
@@ -13,7 +13,8 @@
       ],
       "GET" : [
         {"name" : "get1", "URL":  "/get_test"},
-        {"name": "get2", "URL": "/get_test2/:id"}
+        {"name": "get2", "URL": "/get_test2/:id"},
+        {"name" : "get3", "URL":  "/get_test3"}
       ]
     }
   ],


### PR DESCRIPTION
Pull request to fix #105 

GET Outputs are now activated as soon as the REST server is started (Unless before when they where only activated the first time they were used).

Making the change, exposed that we relied on this behavior for the testing, which I also changed. I also added a new test case, to test that before creating resources, a GETOutput responds with "" instead of a 404.

POSTInputs behave in the same way (Are also activated the first time they are used), however, because they activate when their `read()` method is called, I believe there will not be a situation in which a request is made and they are not activated (Read is called before doing anything else. 

